### PR TITLE
Use error-chain to facilitate error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ name = "cron"
 [dependencies]
 chrono = "~0.3"
 nom = "~2.1"
+error-chain="~0.10.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,8 @@
+error_chain! {
+    errors {
+        Expression(s: String) {
+            description("invalid expression")
+            display("invalid expression: {}", s)
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,11 @@
 extern crate chrono;
 extern crate nom;
 
+#[macro_use]
+extern crate error_chain;
+
 mod time_unit;
 mod schedule;
+pub mod error;
 
 pub use schedule::Schedule;

--- a/src/time_unit/days_of_week.rs
+++ b/src/time_unit/days_of_week.rs
@@ -1,6 +1,7 @@
-use schedule::{Ordinal, OrdinalSet, ExpressionError};
+use schedule::{Ordinal, OrdinalSet};
 use time_unit::TimeUnitField;
 use std::borrow::Cow;
+use error::*;
 
 pub struct DaysOfWeek(OrdinalSet);
 
@@ -17,7 +18,7 @@ impl TimeUnitField for DaysOfWeek {
     fn inclusive_max() -> Ordinal {
         7
     }
-    fn ordinal_from_name(name: &str) -> Result<Ordinal, ExpressionError> {
+    fn ordinal_from_name(name: &str) -> Result<Ordinal> {
         //TODO: Use phf crate
         let ordinal = match name.to_lowercase().as_ref() {
             "sun" | "sunday" => 1,
@@ -27,7 +28,7 @@ impl TimeUnitField for DaysOfWeek {
             "thu" | "thurs" | "thursday" => 5,
             "fri" | "friday" => 6,
             "sat" | "saturday" => 7,
-            _ => return Err(ExpressionError(format!("'{}' is not a valid day of the week.", name))),
+            _ => bail!(ErrorKind::Expression(format!("'{}' is not a valid day of the week.", name))),
         };
         Ok(ordinal)
     }

--- a/src/time_unit/months.rs
+++ b/src/time_unit/months.rs
@@ -1,4 +1,5 @@
-use schedule::{Ordinal, OrdinalSet, ExpressionError};
+use schedule::{Ordinal, OrdinalSet};
+use error::*;
 use time_unit::TimeUnitField;
 use std::borrow::Cow;
 
@@ -17,7 +18,7 @@ impl TimeUnitField for Months {
     fn inclusive_max() -> Ordinal {
         12
     }
-    fn ordinal_from_name(name: &str) -> Result<Ordinal, ExpressionError> {
+    fn ordinal_from_name(name: &str) -> Result<Ordinal> {
         //TODO: Use phf crate
         let ordinal = match name.to_lowercase().as_ref() {
             "jan" | "january" => 1,
@@ -32,7 +33,7 @@ impl TimeUnitField for Months {
             "oct" | "october" => 10,
             "nov" | "november" => 11,
             "dec" | "december" => 12,
-            _ => return Err(ExpressionError(format!("'{}' is not a valid month name.", name))),
+            _ => bail!(ErrorKind::Expression(format!("'{}' is not a valid month name.", name))),
         };
         Ok(ordinal)
     }


### PR DESCRIPTION
Primary motivation is:
1. `ExpressionError` is private
2. `ExpressionError` does not `impl Error`

My use case would be solved by the above and I felt using error-chain could do that nicely.