### PR TITLE
[WIP] Make seconds optional

### DIFF
--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -22,15 +22,19 @@ pub struct Schedule {
 impl Schedule {
     fn from_field_list(fields: Vec<Field>) -> Result<Schedule, Error> {
         let number_of_fields = fields.len();
-        if number_of_fields != 6 && number_of_fields != 7 {
+        if number_of_fields < 5 || number_of_fields > 7 {
             bail!(ErrorKind::Expression(format!("Expression has {} fields. Valid cron \
-                                                expressions have 6 or 7.",
+                                                expressions have 5 to 7.",
                                                 number_of_fields)));
         }
 
         let mut iter = fields.into_iter();
 
-        let seconds = Seconds::from_field(iter.next().unwrap())?;
+        let mut seconds = Seconds::from_ordinal(0);
+        if number_of_fields > 5 {
+            seconds = Seconds::from_field(iter.next().unwrap())?;
+        }
+
         let minutes = Minutes::from_field(iter.next().unwrap())?;
         let hours = Hours::from_field(iter.next().unwrap())?;
         let days_of_month = DaysOfMonth::from_field(iter.next().unwrap())?;
@@ -511,7 +515,7 @@ named!(longhand <Schedule>,
   map_res!(
     complete!(
       do_parse!(
-        fields: many_m_n!(6, 7, field) >>
+        fields: many_m_n!(5, 7, field) >>
         eof!() >>
         (fields)
       )

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -77,6 +77,12 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_without_seconds() {
+        let expression = "0/30 * * * *";
+        assert!(Schedule::from_str(expression).is_ok());
+    }
+
+    #[test]
     fn test_parse_too_many_fields() {
         let expression = "1 2 3 4 5 6 7 8 9 2019";
         assert!(Schedule::from_str(expression).is_err());


### PR DESCRIPTION
Any ideas on how to achieve this ?

> Issue https://github.com/zslayton/cron/issues/13
> Importantly, expressions that do not include seconds but which do include years would be illegal.

For this to work, I guess we have to parse the last part of the cron expression and check if it is an year and err out if seconds is not included. 

I am wondering why this expression works `0/30 * * * *` and this doesn't `*/30 * * * *`. 