### PR TITLE
Bring up to date with current rust Nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 #![cfg_attr(feature="clippy", feature(plugin))]
 #![cfg_attr(feature="clippy", plugin(clippy))]
 #![feature(collections_range)]
-#![feature(conservative_impl_trait)]
 #![feature(iterator_step_by)]
 
 //! A cron expression parser and schedule explorer

--- a/src/time_unit/mod.rs
+++ b/src/time_unit/mod.rs
@@ -15,7 +15,8 @@ pub use self::days_of_week::DaysOfWeek;
 pub use self::years::Years;
 
 use std::collections::btree_set;
-use std::collections::range::{RangeArgument};
+//use std::collections::range::{RangeArgument};
+use std::ops::RangeBounds;
 use schedule::{Specifier, Ordinal, OrdinalSet};
 use error::*;
 use std::borrow::Cow;
@@ -127,7 +128,7 @@ pub trait TimeUnitSpec {
   /// assert_eq!(Some(15), mid_month_paydays.next());
   /// assert_eq!(None, mid_month_paydays.next());
   /// ```
-  fn range<'a, R>(&'a self, range: R) -> OrdinalRangeIter<'a> where R: RangeArgument<Ordinal>;
+  fn range<'a, R>(&'a self, range: R) -> OrdinalRangeIter<'a> where R: RangeBounds<Ordinal>;
 
   /// Returns the number of ordinals included in the associated schedule
   /// # Example
@@ -152,7 +153,7 @@ impl <T> TimeUnitSpec for T where T: TimeUnitField {
       set_iter: TimeUnitField::ordinals(self).iter()
     }
   }
-  fn range<'a, R>(&'a self, range: R) -> OrdinalRangeIter<'a> where R: RangeArgument<Ordinal> {
+  fn range<'a, R>(&'a self, range: R) -> OrdinalRangeIter<'a> where R: RangeBounds<Ordinal> {
     OrdinalRangeIter {
       range_iter: TimeUnitField::ordinals(self).range(range)
     }

--- a/src/time_unit/mod.rs
+++ b/src/time_unit/mod.rs
@@ -15,7 +15,6 @@ pub use self::days_of_week::DaysOfWeek;
 pub use self::years::Years;
 
 use std::collections::btree_set;
-//use std::collections::range::{RangeArgument};
 use std::ops::RangeBounds;
 use schedule::{Specifier, Ordinal, OrdinalSet};
 use error::*;


### PR DESCRIPTION
Nightly changed the API for collections_range somewhat. Also, the conservative_impl_trait feature is no longer required as it's now in a stable as of 1.26. Associated issue: https://github.com/zslayton/cron/issues/35