### PR TITLE
With rust 1.28.0 cron compiles on stable rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 language: rust
-rust: nightly
+rust:
+  - nightly
+  - 1.28.0
+matrix:
+  allow_failures:
+    - rust: nightly
+  fast_finish: true
 script:
 - |
   cargo build &&

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,5 @@
-#![cfg_attr(feature="clippy", feature(plugin))]
-#![cfg_attr(feature="clippy", plugin(clippy))]
-#![feature(collections_range)]
-#![feature(iterator_step_by)]
+#![cfg_attr(feature = "clippy", feature(plugin))]
+#![cfg_attr(feature = "clippy", plugin(clippy))]
 
 //! A cron expression parser and schedule explorer
 //! # Example


### PR DESCRIPTION
The tests on travis are run with `1.28.0` and nightly which is allowed
to fail.

Fixes #22