### PR TITLE
Expose Schedule::next_after()

### DIFF
--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -160,7 +160,8 @@ impl Schedule {
     }
 
 
-  fn next_after<Z>(&self, after: &DateTime<Z>) -> Option<DateTime<Z>> where Z: TimeZone {
+  /// The next matching `DateTime` after the specified one, if one exists.
+  pub fn next_after<Z>(&self, after: &DateTime<Z>) -> Option<DateTime<Z>> where Z: TimeZone {
     let mut query = NextAfterQuery::from(after);
     for year in self.years
       .ordinals()


### PR DESCRIPTION
In some situations it's more convenient to call this function directly, rather than using the iterators.