### PR TITLE
Update nom to version 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 rust:
   - nightly
-  - 1.28.0
+  - 1.30.0
 matrix:
   allow_failures:
     - rust: nightly
@@ -21,4 +21,3 @@ after_success: |
   sudo pip install ghp-import &&
   ghp-import -n target/doc &&
   git push -fq https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git gh-pages
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,5 @@ name = "cron"
 
 [dependencies]
 chrono = "~0.4"
-nom = "~2.1"
+nom = "~4.1"
 error-chain="~0.10.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //! use cron::Schedule;
 //! use chrono::Utc;
 //! use std::str::FromStr;
-//! 
+//!
 //! fn main() {
 //!   //               sec  min   hour   day of month   month   day of week   year
 //!   let expression = "0   30   9,12,15     1,15       May-Aug  Mon,Wed,Fri  2018/2";
@@ -20,7 +20,7 @@
 //!     println!("-> {}", datetime);
 //!   }
 //! }
-//! 
+//!
 //! /*
 //! Upcoming fire times:
 //! -> 2018-06-01 09:30:00 UTC
@@ -42,9 +42,9 @@ extern crate nom;
 #[macro_use]
 extern crate error_chain;
 
-mod time_unit;
-mod schedule;
 pub mod error;
+mod schedule;
+mod time_unit;
 
 pub use schedule::Schedule;
 pub use time_unit::TimeUnitSpec;

--- a/src/time_unit/days_of_month.rs
+++ b/src/time_unit/days_of_month.rs
@@ -1,6 +1,6 @@
 use schedule::{Ordinal, OrdinalSet};
-use time_unit::TimeUnitField;
 use std::borrow::Cow;
+use time_unit::TimeUnitField;
 
 pub struct DaysOfMonth(OrdinalSet);
 

--- a/src/time_unit/days_of_week.rs
+++ b/src/time_unit/days_of_week.rs
@@ -1,7 +1,7 @@
-use schedule::{Ordinal, OrdinalSet};
-use time_unit::TimeUnitField;
-use std::borrow::Cow;
 use error::*;
+use schedule::{Ordinal, OrdinalSet};
+use std::borrow::Cow;
+use time_unit::TimeUnitField;
 
 pub struct DaysOfWeek(OrdinalSet);
 
@@ -28,7 +28,10 @@ impl TimeUnitField for DaysOfWeek {
             "thu" | "thurs" | "thursday" => 5,
             "fri" | "friday" => 6,
             "sat" | "saturday" => 7,
-            _ => bail!(ErrorKind::Expression(format!("'{}' is not a valid day of the week.", name))),
+            _ => bail!(ErrorKind::Expression(format!(
+                "'{}' is not a valid day of the week.",
+                name
+            ))),
         };
         Ok(ordinal)
     }

--- a/src/time_unit/hours.rs
+++ b/src/time_unit/hours.rs
@@ -1,6 +1,6 @@
 use schedule::{Ordinal, OrdinalSet};
-use time_unit::TimeUnitField;
 use std::borrow::Cow;
+use time_unit::TimeUnitField;
 
 pub struct Hours(OrdinalSet);
 

--- a/src/time_unit/minutes.rs
+++ b/src/time_unit/minutes.rs
@@ -1,6 +1,6 @@
 use schedule::{Ordinal, OrdinalSet};
-use time_unit::TimeUnitField;
 use std::borrow::Cow;
+use time_unit::TimeUnitField;
 
 pub struct Minutes(OrdinalSet);
 

--- a/src/time_unit/mod.rs
+++ b/src/time_unit/mod.rs
@@ -1,46 +1,46 @@
-mod seconds;
-mod minutes;
-mod hours;
 mod days_of_month;
-mod months;
 mod days_of_week;
+mod hours;
+mod minutes;
+mod months;
+mod seconds;
 mod years;
 
-pub use self::seconds::Seconds;
-pub use self::minutes::Minutes;
-pub use self::hours::Hours;
 pub use self::days_of_month::DaysOfMonth;
-pub use self::months::Months;
 pub use self::days_of_week::DaysOfWeek;
+pub use self::hours::Hours;
+pub use self::minutes::Minutes;
+pub use self::months::Months;
+pub use self::seconds::Seconds;
 pub use self::years::Years;
 
-use std::collections::btree_set;
-use std::ops::RangeBounds;
-use schedule::{Specifier, Ordinal, OrdinalSet};
 use error::*;
+use schedule::{Ordinal, OrdinalSet, Specifier};
 use std::borrow::Cow;
+use std::collections::btree_set;
 use std::iter;
+use std::ops::RangeBounds;
 
 pub struct OrdinalIter<'a> {
-    set_iter: btree_set::Iter<'a, Ordinal>
+    set_iter: btree_set::Iter<'a, Ordinal>,
 }
 
-impl <'a> Iterator for OrdinalIter<'a> {
+impl<'a> Iterator for OrdinalIter<'a> {
     type Item = Ordinal;
     fn next(&mut self) -> Option<Ordinal> {
-      self.set_iter.next().map(|ordinal| ordinal.clone()) // No real expense; Ordinal is u32: Copy
+        self.set_iter.next().map(|ordinal| ordinal.clone()) // No real expense; Ordinal is u32: Copy
     }
 }
 
 pub struct OrdinalRangeIter<'a> {
-  range_iter: btree_set::Range<'a, Ordinal>
+    range_iter: btree_set::Range<'a, Ordinal>,
 }
 
-impl <'a> Iterator for OrdinalRangeIter<'a> {
-  type Item = Ordinal;
-  fn next(&mut self) -> Option<Ordinal> {
-    self.range_iter.next().map(|ordinal| ordinal.clone()) // No real expense; Ordinal is u32: Copy
-  }
+impl<'a> Iterator for OrdinalRangeIter<'a> {
+    type Item = Ordinal;
+    fn next(&mut self) -> Option<Ordinal> {
+        self.range_iter.next().map(|ordinal| ordinal.clone()) // No real expense; Ordinal is u32: Copy
+    }
 }
 
 /// Methods exposing a schedule's configured ordinals for each individual unit of time.
@@ -76,94 +76,103 @@ impl <'a> Iterator for OrdinalRangeIter<'a> {
 /// assert_eq!(None, five_year_plan.next());
 /// ```
 pub trait TimeUnitSpec {
-  /// Returns true if the provided ordinal was included in the schedule spec for the unit of time
-  /// being described.
-  /// # Example
-  /// ```
-  /// use cron::{Schedule,TimeUnitSpec};
-  /// use std::str::FromStr;
-  ///
-  /// let expression = "* * * * * * 2015-2044";
-  /// let schedule = Schedule::from_str(expression).expect("Failed to parse expression.");
-  ///
-  /// // Membership
-  /// assert_eq!(true, schedule.years().includes(2031));
-  /// assert_eq!(false, schedule.years().includes(2004));
-  /// ```
-  fn includes(&self, ordinal: Ordinal) -> bool;
+    /// Returns true if the provided ordinal was included in the schedule spec for the unit of time
+    /// being described.
+    /// # Example
+    /// ```
+    /// use cron::{Schedule,TimeUnitSpec};
+    /// use std::str::FromStr;
+    ///
+    /// let expression = "* * * * * * 2015-2044";
+    /// let schedule = Schedule::from_str(expression).expect("Failed to parse expression.");
+    ///
+    /// // Membership
+    /// assert_eq!(true, schedule.years().includes(2031));
+    /// assert_eq!(false, schedule.years().includes(2004));
+    /// ```
+    fn includes(&self, ordinal: Ordinal) -> bool;
 
-  /// Provides an iterator which will return each included ordinal for this schedule in order from
-  /// lowest to highest.
-  /// # Example
-  /// ```
-  /// use cron::{Schedule,TimeUnitSpec};
-  /// use std::str::FromStr;
-  ///
-  /// let expression = "* * * * 5-8 * *";
-  /// let schedule = Schedule::from_str(expression).expect("Failed to parse expression.");
-  ///
-  /// // Iterator
-  /// let mut summer = schedule.months().iter();
-  /// assert_eq!(Some(5), summer.next());
-  /// assert_eq!(Some(6), summer.next());
-  /// assert_eq!(Some(7), summer.next());
-  /// assert_eq!(Some(8), summer.next());
-  /// assert_eq!(None, summer.next());
-  /// ```
-  fn iter<'a>(&'a self) -> OrdinalIter<'a>;
+    /// Provides an iterator which will return each included ordinal for this schedule in order from
+    /// lowest to highest.
+    /// # Example
+    /// ```
+    /// use cron::{Schedule,TimeUnitSpec};
+    /// use std::str::FromStr;
+    ///
+    /// let expression = "* * * * 5-8 * *";
+    /// let schedule = Schedule::from_str(expression).expect("Failed to parse expression.");
+    ///
+    /// // Iterator
+    /// let mut summer = schedule.months().iter();
+    /// assert_eq!(Some(5), summer.next());
+    /// assert_eq!(Some(6), summer.next());
+    /// assert_eq!(Some(7), summer.next());
+    /// assert_eq!(Some(8), summer.next());
+    /// assert_eq!(None, summer.next());
+    /// ```
+    fn iter<'a>(&'a self) -> OrdinalIter<'a>;
 
-  /// Provides an iterator which will return each included ordinal within the specified range.
-  /// # Example
-  /// ```
-  /// use cron::{Schedule,TimeUnitSpec};
-  /// use std::collections::Bound::{Included,Excluded};
-  /// use std::str::FromStr;
-  ///
-  /// let expression = "* * * 1,15 * * *";
-  /// let schedule = Schedule::from_str(expression).expect("Failed to parse expression.");
-  ///
-  /// // Range Iterator
-  /// let mut mid_month_paydays = schedule.days_of_month().range((Included(10), Included(20)));
-  /// assert_eq!(Some(15), mid_month_paydays.next());
-  /// assert_eq!(None, mid_month_paydays.next());
-  /// ```
-  fn range<'a, R>(&'a self, range: R) -> OrdinalRangeIter<'a> where R: RangeBounds<Ordinal>;
+    /// Provides an iterator which will return each included ordinal within the specified range.
+    /// # Example
+    /// ```
+    /// use cron::{Schedule,TimeUnitSpec};
+    /// use std::collections::Bound::{Included,Excluded};
+    /// use std::str::FromStr;
+    ///
+    /// let expression = "* * * 1,15 * * *";
+    /// let schedule = Schedule::from_str(expression).expect("Failed to parse expression.");
+    ///
+    /// // Range Iterator
+    /// let mut mid_month_paydays = schedule.days_of_month().range((Included(10), Included(20)));
+    /// assert_eq!(Some(15), mid_month_paydays.next());
+    /// assert_eq!(None, mid_month_paydays.next());
+    /// ```
+    fn range<'a, R>(&'a self, range: R) -> OrdinalRangeIter<'a>
+    where
+        R: RangeBounds<Ordinal>;
 
-  /// Returns the number of ordinals included in the associated schedule
-  /// # Example
-  /// ```
-  /// use cron::{Schedule,TimeUnitSpec};
-  /// use std::str::FromStr;
-  ///
-  /// let expression = "* * * 1,15 * * *";
-  /// let schedule = Schedule::from_str(expression).expect("Failed to parse expression.");
-  ///
-  /// assert_eq!(2, schedule.days_of_month().count());
-  /// ```
-  fn count(&self) -> u32;
+    /// Returns the number of ordinals included in the associated schedule
+    /// # Example
+    /// ```
+    /// use cron::{Schedule,TimeUnitSpec};
+    /// use std::str::FromStr;
+    ///
+    /// let expression = "* * * 1,15 * * *";
+    /// let schedule = Schedule::from_str(expression).expect("Failed to parse expression.");
+    ///
+    /// assert_eq!(2, schedule.days_of_month().count());
+    /// ```
+    fn count(&self) -> u32;
 }
 
-impl <T> TimeUnitSpec for T where T: TimeUnitField {
-  fn includes(&self, ordinal: Ordinal) -> bool {
-    self.ordinals().contains(&ordinal)
-  }
-  fn iter<'a>(&'a self) -> OrdinalIter<'a> {
-    OrdinalIter {
-      set_iter: TimeUnitField::ordinals(self).iter()
+impl<T> TimeUnitSpec for T
+where
+    T: TimeUnitField,
+{
+    fn includes(&self, ordinal: Ordinal) -> bool {
+        self.ordinals().contains(&ordinal)
     }
-  }
-  fn range<'a, R>(&'a self, range: R) -> OrdinalRangeIter<'a> where R: RangeBounds<Ordinal> {
-    OrdinalRangeIter {
-      range_iter: TimeUnitField::ordinals(self).range(range)
+    fn iter<'a>(&'a self) -> OrdinalIter<'a> {
+        OrdinalIter {
+            set_iter: TimeUnitField::ordinals(self).iter(),
+        }
     }
-  }
-  fn count(&self) -> u32 {
-    self.ordinals().len() as u32
-  }
+    fn range<'a, R>(&'a self, range: R) -> OrdinalRangeIter<'a>
+    where
+        R: RangeBounds<Ordinal>,
+    {
+        OrdinalRangeIter {
+            range_iter: TimeUnitField::ordinals(self).range(range),
+        }
+    }
+    fn count(&self) -> u32 {
+        self.ordinals().len() as u32
+    }
 }
 
 pub trait TimeUnitField
-    where Self: Sized
+where
+    Self: Sized,
 {
     fn from_ordinal_set(ordinal_set: OrdinalSet) -> Self;
     fn name() -> Cow<'static, str>;
@@ -180,27 +189,29 @@ pub trait TimeUnitField
         Self::from_ordinal_set(Self::supported_ordinals())
     }
     fn ordinal_from_name(name: &str) -> Result<Ordinal> {
-        bail!(ErrorKind::Expression(format!("The '{}' field does not support using names. '{}' \
-                                     specified.",
-                                            Self::name(),
-                                            name)))
+        bail!(ErrorKind::Expression(format!(
+            "The '{}' field does not support using names. '{}' \
+             specified.",
+            Self::name(),
+            name
+        )))
     }
     fn validate_ordinal(ordinal: Ordinal) -> Result<Ordinal> {
         //println!("validate_ordinal for {} => {}", Self::name(), ordinal);
         match ordinal {
-            i if i < Self::inclusive_min() => {
-                bail!(ErrorKind::Expression(format!("{} must be greater than or equal to {}. ('{}' \
-                                             specified.)",
-                                                    Self::name(),
-                                                    Self::inclusive_min(),
-                                                    i)))
-            }
-            i if i > Self::inclusive_max() => {
-                bail!(ErrorKind::Expression(format!("{} must be less than {}. ('{}' specified.)",
-                                                    Self::name(),
-                                                    Self::inclusive_max(),
-                                                    i)))
-            }
+            i if i < Self::inclusive_min() => bail!(ErrorKind::Expression(format!(
+                "{} must be greater than or equal to {}. ('{}' \
+                 specified.)",
+                Self::name(),
+                Self::inclusive_min(),
+                i
+            ))),
+            i if i > Self::inclusive_max() => bail!(ErrorKind::Expression(format!(
+                "{} must be less than {}. ('{}' specified.)",
+                Self::name(),
+                Self::inclusive_max(),
+                i
+            ))),
             i => Ok(i),
         }
     }
@@ -211,27 +222,25 @@ pub trait TimeUnitField
         match *specifier {
             All => Ok(Self::supported_ordinals()),
             Point(ordinal) => Ok((&[ordinal]).iter().cloned().collect()),
-            NamedPoint(ref name) => {
-                Ok((&[Self::ordinal_from_name(name)?])
-                       .iter()
-                       .cloned()
-                       .collect())
-            }
+            NamedPoint(ref name) => Ok((&[Self::ordinal_from_name(name)?])
+                .iter()
+                .cloned()
+                .collect()),
             Period(start, step) => {
                 let start = Self::validate_ordinal(start)?;
                 Ok((start..Self::inclusive_max() + 1)
-                       .step_by(step as usize)
-                       .collect())
+                    .step_by(step as usize)
+                    .collect())
             }
             Range(start, end) => {
                 match (Self::validate_ordinal(start), Self::validate_ordinal(end)) {
                     (Ok(start), Ok(end)) if start <= end => Ok((start..end + 1).collect()),
-                    _ => {
-                        bail!(ErrorKind::Expression(format!("Invalid range for {}: {}-{}",
-                                                            Self::name(),
-                                                            start,
-                                                            end)))
-                    }
+                    _ => bail!(ErrorKind::Expression(format!(
+                        "Invalid range for {}: {}-{}",
+                        Self::name(),
+                        start,
+                        end
+                    ))),
                 }
             }
             NamedRange(ref start_name, ref end_name) => {
@@ -239,12 +248,12 @@ pub trait TimeUnitField
                 let end = Self::ordinal_from_name(end_name)?;
                 match (Self::validate_ordinal(start), Self::validate_ordinal(end)) {
                     (Ok(start), Ok(end)) if start <= end => Ok((start..end + 1).collect()),
-                    _ => {
-                        bail!(ErrorKind::Expression(format!("Invalid named range for {}: {}-{}",
-                                                            Self::name(),
-                                                            start_name,
-                                                            end_name)))
-                    }
+                    _ => bail!(ErrorKind::Expression(format!(
+                        "Invalid named range for {}: {}-{}",
+                        Self::name(),
+                        start_name,
+                        end_name
+                    ))),
                 }
             }
         }

--- a/src/time_unit/months.rs
+++ b/src/time_unit/months.rs
@@ -1,7 +1,7 @@
-use schedule::{Ordinal, OrdinalSet};
 use error::*;
-use time_unit::TimeUnitField;
+use schedule::{Ordinal, OrdinalSet};
 use std::borrow::Cow;
+use time_unit::TimeUnitField;
 
 pub struct Months(OrdinalSet);
 
@@ -33,7 +33,10 @@ impl TimeUnitField for Months {
             "oct" | "october" => 10,
             "nov" | "november" => 11,
             "dec" | "december" => 12,
-            _ => bail!(ErrorKind::Expression(format!("'{}' is not a valid month name.", name))),
+            _ => bail!(ErrorKind::Expression(format!(
+                "'{}' is not a valid month name.",
+                name
+            ))),
         };
         Ok(ordinal)
     }

--- a/src/time_unit/seconds.rs
+++ b/src/time_unit/seconds.rs
@@ -1,6 +1,6 @@
 use schedule::{Ordinal, OrdinalSet};
-use time_unit::TimeUnitField;
 use std::borrow::Cow;
+use time_unit::TimeUnitField;
 
 pub struct Seconds(OrdinalSet);
 

--- a/src/time_unit/years.rs
+++ b/src/time_unit/years.rs
@@ -1,6 +1,6 @@
 use schedule::{Ordinal, OrdinalSet};
-use time_unit::TimeUnitField;
 use std::borrow::Cow;
+use time_unit::TimeUnitField;
 
 pub struct Years(OrdinalSet);
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,18 +1,12 @@
-extern crate cron;
 extern crate chrono;
+extern crate cron;
 
 #[cfg(test)]
 mod tests {
-    use cron::{
-      Schedule,
-      TimeUnitSpec
-    };
-    use std::collections::Bound::{
-      Included,
-      Excluded
-    };
-    use std::str::FromStr;
     use chrono::*;
+    use cron::{Schedule, TimeUnitSpec};
+    use std::collections::Bound::{Excluded, Included};
+    use std::str::FromStr;
 
     #[test]
     fn test_readme() {
@@ -116,10 +110,14 @@ mod tests {
         let schedule = Schedule::from_str(expression).expect("Failed to parse @monthly.");
         let starting_date = Utc.ymd(2017, 10, 15).and_hms(14, 29, 36);
         let mut events = schedule.after(&starting_date);
-        assert_eq!(Utc.ymd(2017, 11, 1).and_hms(0, 0, 0),
-                   events.next().unwrap());
-        assert_eq!(Utc.ymd(2017, 12, 1).and_hms(0, 0, 0),
-                   events.next().unwrap());
+        assert_eq!(
+            Utc.ymd(2017, 11, 1).and_hms(0, 0, 0),
+            events.next().unwrap()
+        );
+        assert_eq!(
+            Utc.ymd(2017, 12, 1).and_hms(0, 0, 0),
+            events.next().unwrap()
+        );
         assert_eq!(Utc.ymd(2018, 1, 1).and_hms(0, 0, 0), events.next().unwrap());
     }
 
@@ -129,8 +127,10 @@ mod tests {
         let schedule = Schedule::from_str(expression).expect("Failed to parse @weekly.");
         let starting_date = Utc.ymd(2016, 12, 23).and_hms(14, 29, 36);
         let mut events = schedule.after(&starting_date);
-        assert_eq!(Utc.ymd(2016, 12, 25).and_hms(0, 0, 0),
-                   events.next().unwrap());
+        assert_eq!(
+            Utc.ymd(2016, 12, 25).and_hms(0, 0, 0),
+            events.next().unwrap()
+        );
         assert_eq!(Utc.ymd(2017, 1, 1).and_hms(0, 0, 0), events.next().unwrap());
         assert_eq!(Utc.ymd(2017, 1, 8).and_hms(0, 0, 0), events.next().unwrap());
     }
@@ -141,10 +141,14 @@ mod tests {
         let schedule = Schedule::from_str(expression).expect("Failed to parse @daily.");
         let starting_date = Utc.ymd(2016, 12, 29).and_hms(14, 29, 36);
         let mut events = schedule.after(&starting_date);
-        assert_eq!(Utc.ymd(2016, 12, 30).and_hms(0, 0, 0),
-                   events.next().unwrap());
-        assert_eq!(Utc.ymd(2016, 12, 31).and_hms(0, 0, 0),
-                   events.next().unwrap());
+        assert_eq!(
+            Utc.ymd(2016, 12, 30).and_hms(0, 0, 0),
+            events.next().unwrap()
+        );
+        assert_eq!(
+            Utc.ymd(2016, 12, 31).and_hms(0, 0, 0),
+            events.next().unwrap()
+        );
         assert_eq!(Utc.ymd(2017, 1, 1).and_hms(0, 0, 0), events.next().unwrap());
     }
 
@@ -154,12 +158,18 @@ mod tests {
         let schedule = Schedule::from_str(expression).expect("Failed to parse @hourly.");
         let starting_date = Utc.ymd(2017, 2, 25).and_hms(22, 29, 36);
         let mut events = schedule.after(&starting_date);
-        assert_eq!(Utc.ymd(2017, 2, 25).and_hms(23, 0, 0),
-                   events.next().unwrap());
-        assert_eq!(Utc.ymd(2017, 2, 26).and_hms(0, 0, 0),
-                   events.next().unwrap());
-        assert_eq!(Utc.ymd(2017, 2, 26).and_hms(1, 0, 0),
-                   events.next().unwrap());
+        assert_eq!(
+            Utc.ymd(2017, 2, 25).and_hms(23, 0, 0),
+            events.next().unwrap()
+        );
+        assert_eq!(
+            Utc.ymd(2017, 2, 26).and_hms(0, 0, 0),
+            events.next().unwrap()
+        );
+        assert_eq!(
+            Utc.ymd(2017, 2, 26).and_hms(1, 0, 0),
+            events.next().unwrap()
+        );
     }
 
     #[test]
@@ -170,127 +180,139 @@ mod tests {
         let mut events = schedule.after(&starting_date);
 
         assert_eq!(Utc.ymd(2018, 1, 1).and_hms(0, 0, 0), events.next().unwrap());
-        assert_eq!(Utc.ymd(2018, 1, 1).and_hms(0, 0, 20),
-                   events.next().unwrap());
-        assert_eq!(Utc.ymd(2018, 1, 1).and_hms(0, 0, 40),
-                   events.next().unwrap());
+        assert_eq!(
+            Utc.ymd(2018, 1, 1).and_hms(0, 0, 20),
+            events.next().unwrap()
+        );
+        assert_eq!(
+            Utc.ymd(2018, 1, 1).and_hms(0, 0, 40),
+            events.next().unwrap()
+        );
 
         assert_eq!(Utc.ymd(2018, 1, 1).and_hms(0, 5, 0), events.next().unwrap());
-        assert_eq!(Utc.ymd(2018, 1, 1).and_hms(0, 5, 20),
-                   events.next().unwrap());
-        assert_eq!(Utc.ymd(2018, 1, 1).and_hms(0, 5, 40),
-                   events.next().unwrap());
+        assert_eq!(
+            Utc.ymd(2018, 1, 1).and_hms(0, 5, 20),
+            events.next().unwrap()
+        );
+        assert_eq!(
+            Utc.ymd(2018, 1, 1).and_hms(0, 5, 40),
+            events.next().unwrap()
+        );
 
-        assert_eq!(Utc.ymd(2018, 1, 1).and_hms(0, 10, 0),
-                   events.next().unwrap());
-        assert_eq!(Utc.ymd(2018, 1, 1).and_hms(0, 10, 20),
-                   events.next().unwrap());
-        assert_eq!(Utc.ymd(2018, 1, 1).and_hms(0, 10, 40),
-                   events.next().unwrap());
+        assert_eq!(
+            Utc.ymd(2018, 1, 1).and_hms(0, 10, 0),
+            events.next().unwrap()
+        );
+        assert_eq!(
+            Utc.ymd(2018, 1, 1).and_hms(0, 10, 20),
+            events.next().unwrap()
+        );
+        assert_eq!(
+            Utc.ymd(2018, 1, 1).and_hms(0, 10, 40),
+            events.next().unwrap()
+        );
     }
 
     #[test]
     fn test_time_unit_spec_years() {
-      let expression = "* * * * * * 2015-2044";
-      let schedule = Schedule::from_str(expression).expect("Failed to parse expression.");
+        let expression = "* * * * * * 2015-2044";
+        let schedule = Schedule::from_str(expression).expect("Failed to parse expression.");
 
-      // Membership
-      assert_eq!(true, schedule.years().includes(2031));
-      assert_eq!(false, schedule.years().includes(1969));
+        // Membership
+        assert_eq!(true, schedule.years().includes(2031));
+        assert_eq!(false, schedule.years().includes(1969));
 
-      // Number of years specified
-      assert_eq!(30, schedule.years().count());
+        // Number of years specified
+        assert_eq!(30, schedule.years().count());
 
-      // Iterator
-      let mut years_iter = schedule.years().iter();
-      assert_eq!(Some(2015), years_iter.next());
-      assert_eq!(Some(2016), years_iter.next());
-      // ...
+        // Iterator
+        let mut years_iter = schedule.years().iter();
+        assert_eq!(Some(2015), years_iter.next());
+        assert_eq!(Some(2016), years_iter.next());
+        // ...
 
-      // Range Iterator
-      let mut five_year_plan = schedule.years().range((Included(2017), Excluded(2017 + 5)));
-      assert_eq!(Some(2017), five_year_plan.next());
-      assert_eq!(Some(2018), five_year_plan.next());
-      assert_eq!(Some(2019), five_year_plan.next());
-      assert_eq!(Some(2020), five_year_plan.next());
-      assert_eq!(Some(2021), five_year_plan.next());
-      assert_eq!(None, five_year_plan.next());
+        // Range Iterator
+        let mut five_year_plan = schedule.years().range((Included(2017), Excluded(2017 + 5)));
+        assert_eq!(Some(2017), five_year_plan.next());
+        assert_eq!(Some(2018), five_year_plan.next());
+        assert_eq!(Some(2019), five_year_plan.next());
+        assert_eq!(Some(2020), five_year_plan.next());
+        assert_eq!(Some(2021), five_year_plan.next());
+        assert_eq!(None, five_year_plan.next());
     }
 
-  #[test]
-  fn test_time_unit_spec_months() {
-    let expression = "* * * * 5-8 * *";
-    let schedule = Schedule::from_str(expression).expect("Failed to parse expression.");
+    #[test]
+    fn test_time_unit_spec_months() {
+        let expression = "* * * * 5-8 * *";
+        let schedule = Schedule::from_str(expression).expect("Failed to parse expression.");
 
-    // Membership
-    assert_eq!(false, schedule.months().includes(4));
-    assert_eq!(true, schedule.months().includes(6));
+        // Membership
+        assert_eq!(false, schedule.months().includes(4));
+        assert_eq!(true, schedule.months().includes(6));
 
-    // Iterator
-    let mut summer = schedule.months().iter();
-    assert_eq!(Some(5), summer.next());
-    assert_eq!(Some(6), summer.next());
-    assert_eq!(Some(7), summer.next());
-    assert_eq!(Some(8), summer.next());
-    assert_eq!(None, summer.next());
+        // Iterator
+        let mut summer = schedule.months().iter();
+        assert_eq!(Some(5), summer.next());
+        assert_eq!(Some(6), summer.next());
+        assert_eq!(Some(7), summer.next());
+        assert_eq!(Some(8), summer.next());
+        assert_eq!(None, summer.next());
 
-    // Number of months specified
-    assert_eq!(4, schedule.months().count());
+        // Number of months specified
+        assert_eq!(4, schedule.months().count());
 
-    // Range Iterator
-    let mut first_half_of_summer = schedule.months().range((Included(1), Included(6)));
-    assert_eq!(Some(5), first_half_of_summer.next());
-    assert_eq!(Some(6), first_half_of_summer.next());
-    assert_eq!(None, first_half_of_summer.next());
-  }
+        // Range Iterator
+        let mut first_half_of_summer = schedule.months().range((Included(1), Included(6)));
+        assert_eq!(Some(5), first_half_of_summer.next());
+        assert_eq!(Some(6), first_half_of_summer.next());
+        assert_eq!(None, first_half_of_summer.next());
+    }
 
-  #[test]
-  fn test_time_unit_spec_days_of_month() {
-    let expression = "* * * 1,15 * * *";
-    let schedule = Schedule::from_str(expression).expect("Failed to parse expression.");
-    // Membership
-    assert_eq!(true,  schedule.days_of_month().includes(1));
-    assert_eq!(false, schedule.days_of_month().includes(7));
+    #[test]
+    fn test_time_unit_spec_days_of_month() {
+        let expression = "* * * 1,15 * * *";
+        let schedule = Schedule::from_str(expression).expect("Failed to parse expression.");
+        // Membership
+        assert_eq!(true, schedule.days_of_month().includes(1));
+        assert_eq!(false, schedule.days_of_month().includes(7));
 
-    // Iterator
-    let mut paydays = schedule.days_of_month().iter();
-    assert_eq!(Some(1), paydays.next());
-    assert_eq!(Some(15), paydays.next());
-    assert_eq!(None, paydays.next());
+        // Iterator
+        let mut paydays = schedule.days_of_month().iter();
+        assert_eq!(Some(1), paydays.next());
+        assert_eq!(Some(15), paydays.next());
+        assert_eq!(None, paydays.next());
 
-    // Number of years specified
-    assert_eq!(2, schedule.days_of_month().count());
+        // Number of years specified
+        assert_eq!(2, schedule.days_of_month().count());
 
-    // Range Iterator
-    let mut mid_month_paydays = schedule.days_of_month().range((Included(5), Included(25)));
-    assert_eq!(Some(15), mid_month_paydays.next());
-    assert_eq!(None, mid_month_paydays.next());
-  }
+        // Range Iterator
+        let mut mid_month_paydays = schedule.days_of_month().range((Included(5), Included(25)));
+        assert_eq!(Some(15), mid_month_paydays.next());
+        assert_eq!(None, mid_month_paydays.next());
+    }
 
-  #[test]
-  fn test_first_ordinals_not_in_set_1() {
-    let schedule = "0 0/10 * * * * *".parse::<Schedule>().unwrap();
-    let start_time_1 = NaiveDate::from_ymd(2017, 10, 24).and_hms(0, 0, 59);
-    let start_time_1 = Utc.from_utc_datetime(&start_time_1);
-    let next_time_1 = schedule.after(&start_time_1).next().unwrap();
+    #[test]
+    fn test_first_ordinals_not_in_set_1() {
+        let schedule = "0 0/10 * * * * *".parse::<Schedule>().unwrap();
+        let start_time_1 = NaiveDate::from_ymd(2017, 10, 24).and_hms(0, 0, 59);
+        let start_time_1 = Utc.from_utc_datetime(&start_time_1);
+        let next_time_1 = schedule.after(&start_time_1).next().unwrap();
 
-    let start_time_2 = NaiveDate::from_ymd(2017, 10, 24).and_hms(0, 1, 0);
-    let start_time_2 = Utc.from_utc_datetime(&start_time_2);
-    let next_time_2 = schedule.after(&start_time_2).next().unwrap();
-    assert_eq!(next_time_1, next_time_2);
-  }
-  
+        let start_time_2 = NaiveDate::from_ymd(2017, 10, 24).and_hms(0, 1, 0);
+        let start_time_2 = Utc.from_utc_datetime(&start_time_2);
+        let next_time_2 = schedule.after(&start_time_2).next().unwrap();
+        assert_eq!(next_time_1, next_time_2);
+    }
 
+    #[test]
+    fn test_first_ordinals_not_in_set_2() {
+        let schedule_1 = "00 00 23 * * * *".parse::<Schedule>().unwrap();
+        let start_time = NaiveDate::from_ymd(2018, 11, 15).and_hms(22, 30, 00);
+        let start_time = Utc.from_utc_datetime(&start_time);
+        let next_time_1 = schedule_1.after(&start_time).next().unwrap();
 
-#[test]
-  fn test_first_ordinals_not_in_set_2() {
-    let schedule_1 = "00 00 23 * * * *".parse::<Schedule>().unwrap();
-    let start_time = NaiveDate::from_ymd(2018, 11, 15).and_hms(22, 30, 00);
-    let start_time = Utc.from_utc_datetime(&start_time);
-    let next_time_1 = schedule_1.after(&start_time).next().unwrap();
-
-    let schedule_2 = "00 00 * * * * *".parse::<Schedule>().unwrap();
-    let next_time_2 = schedule_2.after(&start_time).next().unwrap();
-    assert_eq!(next_time_1, next_time_2);
-  }
+        let schedule_2 = "00 00 * * * * *".parse::<Schedule>().unwrap();
+        let next_time_2 = schedule_2.after(&start_time).next().unwrap();
+        assert_eq!(next_time_1, next_time_2);
+    }
 }


### PR DESCRIPTION
This updates nom from version 2 to version 4.

The main change is that nom 4 will return an `Incomplete` error in more cases, so the inputs to all the parsers are wrapped in `CompleteStr`.

I also ran rustfmt and changed many of the unit tests to use `unwrap` instead of asserting `.is_ok()`, since it results in more descriptive errors when tests fail.