### PR TITLE
Remove error chain

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 rust:
   - nightly
-  - 1.30.0
+  - 1.28.0
 matrix:
   allow_failures:
     - rust: nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,3 @@ name = "cron"
 [dependencies]
 chrono = "~0.4"
 nom = "~4.1"
-error-chain="~0.10.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,27 @@
-error_chain! {
-    errors {
-        Expression(s: String) {
-            description("invalid expression")
-            display("invalid expression: {}", s)
+use std::{error, fmt};
+
+#[derive(Debug)]
+pub struct Error {
+    kind: ErrorKind,
+}
+
+#[derive(Debug)]
+pub enum ErrorKind {
+    Expression(String),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self.kind {
+            ErrorKind::Expression(ref expr) => write!(f, "Invalid expression: {}", expr),
         }
+    }
+}
+
+impl error::Error for Error {}
+
+impl From<ErrorKind> for Error {
+    fn from(kind: ErrorKind) -> Error {
+        Error { kind }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,9 +39,6 @@
 extern crate chrono;
 extern crate nom;
 
-#[macro_use]
-extern crate error_chain;
-
 pub mod error;
 mod schedule;
 mod time_unit;

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -120,11 +120,12 @@ impl Schedule {
     fn from_field_list(fields: Vec<Field>) -> Result<Schedule, Error> {
         let number_of_fields = fields.len();
         if number_of_fields != 6 && number_of_fields != 7 {
-            bail!(ErrorKind::Expression(format!(
+            return Err(ErrorKind::Expression(format!(
                 "Expression has {} fields. Valid cron \
                  expressions have 6 or 7.",
                 number_of_fields
-            )));
+            ))
+            .into());
         }
 
         let mut iter = fields.into_iter();
@@ -316,7 +317,7 @@ impl FromStr for Schedule {
     fn from_str(expression: &str) -> Result<Self, Self::Err> {
         match schedule(Input(expression)) {
             Ok((_, schedule)) => Ok(schedule), // Extract from nom tuple
-            Err(_) => bail!(ErrorKind::Expression("Invalid cron expression.".to_owned())), //TODO: Details
+            Err(_) => Err(ErrorKind::Expression("Invalid cron expression.".to_owned()).into()), //TODO: Details
         }
     }
 }

--- a/src/time_unit/days_of_week.rs
+++ b/src/time_unit/days_of_week.rs
@@ -18,7 +18,7 @@ impl TimeUnitField for DaysOfWeek {
     fn inclusive_max() -> Ordinal {
         7
     }
-    fn ordinal_from_name(name: &str) -> Result<Ordinal> {
+    fn ordinal_from_name(name: &str) -> Result<Ordinal, Error> {
         //TODO: Use phf crate
         let ordinal = match name.to_lowercase().as_ref() {
             "sun" | "sunday" => 1,
@@ -28,10 +28,13 @@ impl TimeUnitField for DaysOfWeek {
             "thu" | "thurs" | "thursday" => 5,
             "fri" | "friday" => 6,
             "sat" | "saturday" => 7,
-            _ => bail!(ErrorKind::Expression(format!(
-                "'{}' is not a valid day of the week.",
-                name
-            ))),
+            _ => {
+                return Err(ErrorKind::Expression(format!(
+                    "'{}' is not a valid day of the week.",
+                    name
+                ))
+                .into())
+            }
         };
         Ok(ordinal)
     }

--- a/src/time_unit/mod.rs
+++ b/src/time_unit/mod.rs
@@ -188,35 +188,38 @@ where
     fn all() -> Self {
         Self::from_ordinal_set(Self::supported_ordinals())
     }
-    fn ordinal_from_name(name: &str) -> Result<Ordinal> {
-        bail!(ErrorKind::Expression(format!(
+    fn ordinal_from_name(name: &str) -> Result<Ordinal, Error> {
+        Err(ErrorKind::Expression(format!(
             "The '{}' field does not support using names. '{}' \
              specified.",
             Self::name(),
             name
-        )))
+        ))
+        .into())
     }
-    fn validate_ordinal(ordinal: Ordinal) -> Result<Ordinal> {
+    fn validate_ordinal(ordinal: Ordinal) -> Result<Ordinal, Error> {
         //println!("validate_ordinal for {} => {}", Self::name(), ordinal);
         match ordinal {
-            i if i < Self::inclusive_min() => bail!(ErrorKind::Expression(format!(
+            i if i < Self::inclusive_min() => Err(ErrorKind::Expression(format!(
                 "{} must be greater than or equal to {}. ('{}' \
                  specified.)",
                 Self::name(),
                 Self::inclusive_min(),
                 i
-            ))),
-            i if i > Self::inclusive_max() => bail!(ErrorKind::Expression(format!(
+            ))
+            .into()),
+            i if i > Self::inclusive_max() => Err(ErrorKind::Expression(format!(
                 "{} must be less than {}. ('{}' specified.)",
                 Self::name(),
                 Self::inclusive_max(),
                 i
-            ))),
+            ))
+            .into()),
             i => Ok(i),
         }
     }
 
-    fn ordinals_from_specifier(specifier: &Specifier) -> Result<OrdinalSet> {
+    fn ordinals_from_specifier(specifier: &Specifier) -> Result<OrdinalSet, Error> {
         use self::Specifier::*;
         //println!("ordinals_from_specifier for {} => {:?}", Self::name(), specifier);
         match *specifier {
@@ -235,12 +238,13 @@ where
             Range(start, end) => {
                 match (Self::validate_ordinal(start), Self::validate_ordinal(end)) {
                     (Ok(start), Ok(end)) if start <= end => Ok((start..end + 1).collect()),
-                    _ => bail!(ErrorKind::Expression(format!(
+                    _ => Err(ErrorKind::Expression(format!(
                         "Invalid range for {}: {}-{}",
                         Self::name(),
                         start,
                         end
-                    ))),
+                    ))
+                    .into()),
                 }
             }
             NamedRange(ref start_name, ref end_name) => {
@@ -248,12 +252,13 @@ where
                 let end = Self::ordinal_from_name(end_name)?;
                 match (Self::validate_ordinal(start), Self::validate_ordinal(end)) {
                     (Ok(start), Ok(end)) if start <= end => Ok((start..end + 1).collect()),
-                    _ => bail!(ErrorKind::Expression(format!(
+                    _ => Err(ErrorKind::Expression(format!(
                         "Invalid named range for {}: {}-{}",
                         Self::name(),
                         start_name,
                         end_name
-                    ))),
+                    ))
+                    .into()),
                 }
             }
         }

--- a/src/time_unit/months.rs
+++ b/src/time_unit/months.rs
@@ -18,7 +18,7 @@ impl TimeUnitField for Months {
     fn inclusive_max() -> Ordinal {
         12
     }
-    fn ordinal_from_name(name: &str) -> Result<Ordinal> {
+    fn ordinal_from_name(name: &str) -> Result<Ordinal, Error> {
         //TODO: Use phf crate
         let ordinal = match name.to_lowercase().as_ref() {
             "jan" | "january" => 1,
@@ -33,10 +33,11 @@ impl TimeUnitField for Months {
             "oct" | "october" => 10,
             "nov" | "november" => 11,
             "dec" | "december" => 12,
-            _ => bail!(ErrorKind::Expression(format!(
-                "'{}' is not a valid month name.",
-                name
-            ))),
+            _ => {
+                return Err(
+                    ErrorKind::Expression(format!("'{}' is not a valid month name.", name)).into(),
+                )
+            }
         };
         Ok(ordinal)
     }


### PR DESCRIPTION
This turned out to be really easy to do, so merge it or close as you prefer. Since it came in #43 that the `cc` crate no longer compiles on 1.28, I removed the `error-chain` dependency, which was transitively including `cc`. All the errors produced by this crate are just strings anyway. I replaced it with a similar `Error` and `ErrorKind` pair, and implemented `std::error::Error`.

I think this is unlikely to break anyone's code, but it's technically a breaking change.