### PR TITLE
Support for @minute shorthand

### DIFF
--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -9,6 +9,7 @@ use std::str::{self, FromStr};
 
 use time_unit::*;
 
+#[derive(Eq, PartialEq, Clone)]
 pub struct Schedule {
     years: Years,
     days_of_week: DaysOfWeek,

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -552,6 +552,22 @@ named!(
 );
 
 named!(
+    shorthand_minute<Input, Schedule>,
+    do_parse!(
+        tag!("@minute")
+            >> (Schedule::from(
+                Seconds::from_ordinal_set(iter::once(0).collect()),
+                Minutes::all(),
+                Hours::all(),
+                DaysOfMonth::all(),
+                Months::all(),
+                DaysOfWeek::all(),
+                Years::all()
+            ))
+    )
+);
+
+named!(
     shorthand<Input, Schedule>,
     alt!(
         shorthand_yearly
@@ -559,6 +575,7 @@ named!(
             | shorthand_weekly
             | shorthand_daily
             | shorthand_hourly
+            | shorthand_minute
     )
 );
 

--- a/src/time_unit/days_of_month.rs
+++ b/src/time_unit/days_of_month.rs
@@ -2,6 +2,7 @@ use schedule::{Ordinal, OrdinalSet};
 use std::borrow::Cow;
 use time_unit::TimeUnitField;
 
+#[derive(Eq, PartialEq, Clone)]
 pub struct DaysOfMonth(OrdinalSet);
 
 impl TimeUnitField for DaysOfMonth {

--- a/src/time_unit/days_of_week.rs
+++ b/src/time_unit/days_of_week.rs
@@ -3,6 +3,7 @@ use schedule::{Ordinal, OrdinalSet};
 use std::borrow::Cow;
 use time_unit::TimeUnitField;
 
+#[derive(Eq, PartialEq, Clone)]
 pub struct DaysOfWeek(OrdinalSet);
 
 impl TimeUnitField for DaysOfWeek {

--- a/src/time_unit/hours.rs
+++ b/src/time_unit/hours.rs
@@ -2,6 +2,7 @@ use schedule::{Ordinal, OrdinalSet};
 use std::borrow::Cow;
 use time_unit::TimeUnitField;
 
+#[derive(Eq, PartialEq, Clone)]
 pub struct Hours(OrdinalSet);
 
 impl TimeUnitField for Hours {

--- a/src/time_unit/minutes.rs
+++ b/src/time_unit/minutes.rs
@@ -2,6 +2,7 @@ use schedule::{Ordinal, OrdinalSet};
 use std::borrow::Cow;
 use time_unit::TimeUnitField;
 
+#[derive(Eq, PartialEq, Clone)]
 pub struct Minutes(OrdinalSet);
 
 impl TimeUnitField for Minutes {

--- a/src/time_unit/months.rs
+++ b/src/time_unit/months.rs
@@ -3,6 +3,7 @@ use schedule::{Ordinal, OrdinalSet};
 use std::borrow::Cow;
 use time_unit::TimeUnitField;
 
+#[derive(Eq, PartialEq, Clone)]
 pub struct Months(OrdinalSet);
 
 impl TimeUnitField for Months {

--- a/src/time_unit/seconds.rs
+++ b/src/time_unit/seconds.rs
@@ -2,6 +2,7 @@ use schedule::{Ordinal, OrdinalSet};
 use std::borrow::Cow;
 use time_unit::TimeUnitField;
 
+#[derive(Eq, PartialEq, Clone)]
 pub struct Seconds(OrdinalSet);
 
 impl TimeUnitField for Seconds {

--- a/src/time_unit/years.rs
+++ b/src/time_unit/years.rs
@@ -2,6 +2,7 @@ use schedule::{Ordinal, OrdinalSet};
 use std::borrow::Cow;
 use time_unit::TimeUnitField;
 
+#[derive(Eq, PartialEq, Clone)]
 pub struct Years(OrdinalSet);
 
 impl TimeUnitField for Years {


### PR DESCRIPTION
Shorthand `@minute` is now available to create schedule for running every minute:

```rust
let schedule = Schedule::from_str("@minute");
for datetime in schedule.upcoming(Local).take(10) {
    println!("-> {}", datetime);
}
// Output:
// -> 2019-05-29 15:52:00 +05:30
// -> 2019-05-29 15:53:00 +05:30
// -> 2019-05-29 15:54:00 +05:30
// -> 2019-05-29 15:55:00 +05:30
// -> 2019-05-29 15:56:00 +05:30
// -> 2019-05-29 15:57:00 +05:30
// -> 2019-05-29 15:58:00 +05:30
// -> 2019-05-29 15:59:00 +05:30
// -> 2019-05-29 16:00:00 +05:30
// -> 2019-05-29 16:01:00 +05:30
```