### PR TITLE
fix panic on invalid time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,7 @@ name = "cron"
 chrono = "~0.4"
 nom = "~4.1"
 error-chain="~0.10.0"
+
+[dev-dependencies]
+chrono-tz = "0.4"
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,8 @@
 
 extern crate chrono;
 extern crate nom;
+#[cfg(test)]
+extern crate chrono_tz;
 
 #[macro_use]
 extern crate error_chain;


### PR DESCRIPTION
fixes the bug in issue #48 by using `chrono::DateTime::and_hms_opt` to validate whether the `candidate` schedule time exists in that tz. In the event that the `candidate` time is invalid, this code will deem the `candidate` to be a failed one (via the `continue 'day_loop` statement on line 236). I believe this is correct, but I didn't honestly spend a huge amount of time understanding the scheduling logic. This definitely fixes the #48 in terms of the potential panic (and adds a test for that), but it'd be good to review if it correctly handles the failure case in terms of scheduling (perhaps it should increment the `candidate` time to the next hour, or something).