### PR TITLE
impl DoubleEndedIterator for ScheduleIterator

### DIFF
--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -119,6 +119,103 @@ where
     }
 } // End of impl
 
+struct PrevFromQuery<Z>
+where
+    Z: TimeZone,
+{
+    initial_datetime: DateTime<Z>,
+    first_month: bool,
+    first_day_of_month: bool,
+    first_hour: bool,
+    first_minute: bool,
+    first_second: bool,
+}
+
+impl<Z> PrevFromQuery<Z>
+where
+    Z: TimeZone,
+{
+    fn from(before: &DateTime<Z>) -> PrevFromQuery<Z> {
+        PrevFromQuery {
+            initial_datetime: before.clone() - Duration::seconds(1),
+            first_month: true,
+            first_day_of_month: true,
+            first_hour: true,
+            first_minute: true,
+            first_second: true,
+        }
+    }
+
+    fn year_upper_bound(&self) -> Ordinal {
+        // Unlike the other units, years will never wrap around.
+        self.initial_datetime.year() as u32
+    }
+
+    fn month_upper_bound(&mut self) -> Ordinal {
+        if self.first_month {
+            self.first_month = false;
+            return self.initial_datetime.month();
+        }
+        Months::inclusive_max()
+    }
+
+    fn reset_month(&mut self) {
+        self.first_month = false;
+        self.reset_day_of_month();
+    }
+
+    fn day_of_month_lower_bound(&mut self) -> Ordinal {
+        if self.first_day_of_month {
+            self.first_day_of_month = false;
+            return self.initial_datetime.day();
+        }
+        DaysOfMonth::inclusive_min()
+    }
+
+    fn reset_day_of_month(&mut self) {
+        self.first_day_of_month = false;
+        self.reset_hour();
+    }
+
+    fn hour_upper_bound(&mut self) -> Ordinal {
+        if self.first_hour {
+            self.first_hour = false;
+            return self.initial_datetime.hour();
+        }
+        Hours::inclusive_max()
+    }
+
+    fn reset_hour(&mut self) {
+        self.first_hour = false;
+        self.reset_minute();
+    }
+
+    fn minute_upper_bound(&mut self) -> Ordinal {
+        if self.first_minute {
+            self.first_minute = false;
+            return self.initial_datetime.minute();
+        }
+        Minutes::inclusive_max()
+    }
+
+    fn reset_minute(&mut self) {
+        self.first_minute = false;
+        self.reset_second();
+    }
+
+    fn second_upper_bound(&mut self) -> Ordinal {
+        if self.first_second {
+            self.first_second = false;
+            return self.initial_datetime.second();
+        }
+        Seconds::inclusive_max()
+    }
+
+    fn reset_second(&mut self) {
+        self.first_second = false;
+    }
+}
+
 impl Schedule {
     fn from_field_list(fields: Vec<Field>) -> Result<Schedule, Error> {
         let number_of_fields = fields.len();
@@ -165,13 +262,13 @@ impl Schedule {
     ) -> Schedule {
         Schedule {
             source: None,
-            years: years,
-            days_of_week: days_of_week,
-            months: months,
-            days_of_month: days_of_month,
-            hours: hours,
-            minutes: minutes,
-            seconds: seconds,
+            years,
+            days_of_week,
+            months,
+            days_of_month,
+            hours,
+            minutes,
+            seconds,
         }
     }
 
@@ -260,6 +357,96 @@ impl Schedule {
         None
     }
 
+    fn prev_from<Z>(&self, before: &DateTime<Z>) -> Option<DateTime<Z>>
+    where
+        Z: TimeZone,
+    {
+        let mut query = PrevFromQuery::from(before);
+        for year in self
+            .years
+            .ordinals()
+            .range((Unbounded, Included(query.year_upper_bound())))
+            .rev()
+            .cloned()
+        {
+            let month_start = query.month_upper_bound();
+            if !self.months.ordinals().contains(&month_start) {
+                query.reset_month();
+            }
+            let month_range = (Included(Months::inclusive_min()), Included(month_start));
+            for month in self.months.ordinals().range(month_range).rev().cloned() {
+                let day_of_month_start = query.day_of_month_lower_bound();
+                if !self.days_of_month.ordinals().contains(&day_of_month_start) {
+                    query.reset_day_of_month();
+                }
+
+                let day_of_month_end = days_in_month(month, year);
+
+                let day_of_month_range = (Included(day_of_month_start), Included(day_of_month_end));
+
+                'day_loop: for day_of_month in self
+                    .days_of_month
+                    .ordinals()
+                    .range(day_of_month_range)
+                    .rev()
+                    .cloned()
+                {
+                    let hour_start = query.hour_upper_bound();
+                    if !self.hours.ordinals().contains(&hour_start) {
+                        query.reset_hour();
+                    }
+                    let hour_range = (Included(Hours::inclusive_min()), Included(hour_start));
+
+                    for hour in self.hours.ordinals().range(hour_range).rev().cloned() {
+                        let minute_start = query.minute_upper_bound();
+                        if !self.minutes.ordinals().contains(&minute_start) {
+                            query.reset_minute();
+                        }
+                        let minute_range =
+                            (Included(Minutes::inclusive_min()), Included(minute_start));
+
+                        for minute in self.minutes.ordinals().range(minute_range).rev().cloned() {
+                            let second_start = query.second_upper_bound();
+                            if !self.seconds.ordinals().contains(&second_start) {
+                                query.reset_second();
+                            }
+                            let second_range =
+                                (Included(Seconds::inclusive_min()), Included(second_start));
+
+                            for second in self.seconds.ordinals().range(second_range).rev().cloned()
+                            {
+                                let timezone = before.timezone();
+                                let candidate = if let Some(candidate) = timezone
+                                    .ymd(year as i32, month, day_of_month)
+                                    .and_hms_opt(hour, minute, second)
+                                {
+                                    candidate
+                                } else {
+                                    continue;
+                                };
+                                if !self
+                                    .days_of_week
+                                    .ordinals()
+                                    .contains(&candidate.weekday().number_from_sunday())
+                                {
+                                    continue 'day_loop;
+                                }
+                                return Some(candidate);
+                            }
+                            query.reset_minute();
+                        } // End of minutes range
+                        query.reset_hour();
+                    } // End of hours range
+                    query.reset_day_of_month();
+                } // End of Day of Month range
+                query.reset_month();
+            } // End of Month range
+        }
+
+        // We ran out of dates to try.
+        None
+    }
+
     /// Provides an iterator which will return each DateTime that matches the schedule starting with
     /// the current time if applicable.
     pub fn upcoming<Z>(&self, timezone: Z) -> ScheduleIterator<Z>
@@ -270,7 +457,7 @@ impl Schedule {
     }
 
     /// Like the `upcoming` method, but allows you to specify a start time other than the present.
-    pub fn after<'a, Z>(&'a self, after: &DateTime<Z>) -> ScheduleIterator<'a, Z>
+    pub fn after<Z>(&self, after: &DateTime<Z>) -> ScheduleIterator<Z>
     where
         Z: TimeZone,
     {
@@ -362,7 +549,7 @@ where
     fn new(schedule: &'a Schedule, starting_datetime: &DateTime<Z>) -> ScheduleIterator<'a, Z> {
         ScheduleIterator {
             is_done: false,
-            schedule: schedule,
+            schedule,
             previous_datetime: starting_datetime.clone(),
         }
     }
@@ -381,6 +568,25 @@ where
         if let Some(next_datetime) = self.schedule.next_after(&self.previous_datetime) {
             self.previous_datetime = next_datetime.clone();
             Some(next_datetime)
+        } else {
+            self.is_done = true;
+            None
+        }
+    }
+}
+
+impl<'a, Z> DoubleEndedIterator for ScheduleIterator<'a, Z>
+where
+    Z: TimeZone,
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.is_done {
+            return None;
+        }
+
+        if let Some(prev_datetime) = self.schedule.prev_from(&self.previous_datetime) {
+            self.previous_datetime = prev_datetime.clone();
+            Some(prev_datetime)
         } else {
             self.is_done = true;
             None
@@ -647,6 +853,34 @@ fn days_in_month(month: Ordinal, year: Ordinal) -> u32 {
 }
 
 #[test]
+fn test_next_and_prev_from() {
+    let expression = "0 5,13,40-42 17 1 Jan *";
+    let schedule = schedule(Input(expression)).unwrap().1;
+
+    let next = schedule.next_after(&Utc::now());
+    println!("NEXT AFTER for {} {:?}", expression, next);
+    assert!(next.is_some());
+
+    let next2 = schedule.next_after(&next.unwrap());
+    println!("NEXT2 AFTER for {} {:?}", expression, next2);
+    assert!(next2.is_some());
+
+    let prev = schedule.prev_from(&next2.unwrap());
+    println!("PREV FROM for {} {:?}", expression, prev);
+    assert!(prev.is_some());
+    assert_eq!(prev, next);
+}
+
+#[test]
+fn test_prev_from() {
+    let expression = "0 5,13,40-42 17 1 Jan *";
+    let schedule = schedule(Input(expression)).unwrap().1;
+    let prev = schedule.prev_from(&Utc::now());
+    println!("PREV FROM for {} {:?}", expression, prev);
+    assert!(prev.is_some());
+}
+
+#[test]
 fn test_next_after() {
     let expression = "0 5,13,40-42 17 1 Jan *";
     let schedule = schedule(Input(expression)).unwrap().1;
@@ -669,6 +903,22 @@ fn test_upcoming_utc() {
     println!("Upcoming 1 for {} {:?}", expression, next1);
     println!("Upcoming 2 for {} {:?}", expression, next2);
     println!("Upcoming 3 for {} {:?}", expression, next3);
+}
+
+#[test]
+fn test_upcoming_rev_utc() {
+    let expression = "0 0,30 0,6,12,18 1,15 Jan-March Thurs";
+    let schedule = schedule(Input(expression)).unwrap().1;
+    let mut upcoming = schedule.upcoming(Utc).rev();
+    let prev1 = upcoming.next();
+    assert!(prev1.is_some());
+    let prev2 = upcoming.next();
+    assert!(prev2.is_some());
+    let prev3 = upcoming.next();
+    assert!(prev3.is_some());
+    println!("Prev Upcoming 1 for {} {:?}", expression, prev1);
+    println!("Prev Upcoming 2 for {} {:?}", expression, prev2);
+    println!("Prev Upcoming 3 for {} {:?}", expression, prev3);
 }
 
 #[test]

--- a/src/time_unit/mod.rs
+++ b/src/time_unit/mod.rs
@@ -32,6 +32,12 @@ impl<'a> Iterator for OrdinalIter<'a> {
     }
 }
 
+impl<'a> DoubleEndedIterator for OrdinalIter<'a> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.set_iter.next_back().map(|ordinal| ordinal.clone()) // No real expense; Ordinal is u32: Copy
+    }
+}
+
 pub struct OrdinalRangeIter<'a> {
     range_iter: btree_set::Range<'a, Ordinal>,
 }
@@ -40,6 +46,12 @@ impl<'a> Iterator for OrdinalRangeIter<'a> {
     type Item = Ordinal;
     fn next(&mut self) -> Option<Ordinal> {
         self.range_iter.next().map(|ordinal| ordinal.clone()) // No real expense; Ordinal is u32: Copy
+    }
+}
+
+impl<'a> DoubleEndedIterator for OrdinalRangeIter<'a> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.range_iter.next_back().map(|ordinal| ordinal.clone())
     }
 }
 

--- a/src/time_unit/mod.rs
+++ b/src/time_unit/mod.rs
@@ -28,13 +28,13 @@ pub struct OrdinalIter<'a> {
 impl<'a> Iterator for OrdinalIter<'a> {
     type Item = Ordinal;
     fn next(&mut self) -> Option<Ordinal> {
-        self.set_iter.next().map(|ordinal| ordinal.clone()) // No real expense; Ordinal is u32: Copy
+        self.set_iter.next().copied()
     }
 }
 
 impl<'a> DoubleEndedIterator for OrdinalIter<'a> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.set_iter.next_back().map(|ordinal| ordinal.clone()) // No real expense; Ordinal is u32: Copy
+        self.set_iter.next_back().copied()
     }
 }
 
@@ -45,13 +45,13 @@ pub struct OrdinalRangeIter<'a> {
 impl<'a> Iterator for OrdinalRangeIter<'a> {
     type Item = Ordinal;
     fn next(&mut self) -> Option<Ordinal> {
-        self.range_iter.next().map(|ordinal| ordinal.clone()) // No real expense; Ordinal is u32: Copy
+        self.range_iter.next().copied()
     }
 }
 
 impl<'a> DoubleEndedIterator for OrdinalRangeIter<'a> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.range_iter.next_back().map(|ordinal| ordinal.clone())
+        self.range_iter.next_back().copied()
     }
 }
 
@@ -122,7 +122,7 @@ pub trait TimeUnitSpec {
     /// assert_eq!(Some(8), summer.next());
     /// assert_eq!(None, summer.next());
     /// ```
-    fn iter<'a>(&'a self) -> OrdinalIter<'a>;
+    fn iter(&self) -> OrdinalIter;
 
     /// Provides an iterator which will return each included ordinal within the specified range.
     /// # Example
@@ -139,7 +139,7 @@ pub trait TimeUnitSpec {
     /// assert_eq!(Some(15), mid_month_paydays.next());
     /// assert_eq!(None, mid_month_paydays.next());
     /// ```
-    fn range<'a, R>(&'a self, range: R) -> OrdinalRangeIter<'a>
+    fn range<R>(&self, range: R) -> OrdinalRangeIter
     where
         R: RangeBounds<Ordinal>;
 
@@ -164,12 +164,12 @@ where
     fn includes(&self, ordinal: Ordinal) -> bool {
         self.ordinals().contains(&ordinal)
     }
-    fn iter<'a>(&'a self) -> OrdinalIter<'a> {
+    fn iter(&self) -> OrdinalIter {
         OrdinalIter {
             set_iter: TimeUnitField::ordinals(self).iter(),
         }
     }
-    fn range<'a, R>(&'a self, range: R) -> OrdinalRangeIter<'a>
+    fn range<R>(&'_ self, range: R) -> OrdinalRangeIter<'_>
     where
         R: RangeBounds<Ordinal>,
     {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -50,7 +50,6 @@ mod tests {
             date = schedule.after(&date).next().expect("No further dates!");
             println!("-> {}", date);
         }
-        assert!(true);
     }
 
     #[test]
@@ -61,7 +60,6 @@ mod tests {
         for datetime in schedule.upcoming(Utc).take(12) {
             println!("-> {}", datetime);
         }
-        assert!(true);
     }
 
     #[test]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -92,6 +92,18 @@ mod tests {
     }
 
     #[test]
+    fn test_prev_utc() {
+        let expression = "1 2 3 4 10 Fri";
+        let schedule = Schedule::from_str(expression).unwrap();
+        let prev = schedule
+            .upcoming(Utc)
+            .rev()
+            .next()
+            .expect("There was no previous upcoming fire time.");
+        println!("Previous fire time: {}", prev.to_rfc3339());
+    }
+
+    #[test]
     fn test_yearly() {
         let expression = "@yearly";
         let schedule = Schedule::from_str(expression).expect("Failed to parse @yearly.");


### PR DESCRIPTION
This PR implements `DoubleEndedIterator` for `ScheduleIterator` in order to retrieve previous scheduled times.

My use case is I'm building a CRON scheduler using this crate where each run of a scheduled job will save the last time it was successfully run. This saved time will be used by a service using this scheduler to know on startup, either due to scheduled maintenance, downtime or otherwise, If a scheduled job was missed being run during that downtime and should be run immediately to make up for it.

So this will allow checking the previous scheduled run time against the last time it was run in order to make that determination.

P.S. The function name `upcoming` used to get a `ScheduleIterator` does read strange when iterating in reverse over schedule times and perhaps should change with a major version change, but until that time didn't want to make breaking changes.