### PR TITLE
Change fields in schedule to Option<_>

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,5 @@
 #![cfg_attr(feature="clippy", feature(plugin))]
 #![cfg_attr(feature="clippy", plugin(clippy))]
-#![feature(conservative_impl_trait)]
-#![feature(collections_bound)]
-#![feature(btree_range)]
-#![feature(step_by)]
 
 #![allow(dead_code)]
 extern crate chrono;

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -45,13 +45,13 @@ impl Schedule {
                           years))
     }
 
-    fn from(seconds: Seconds,
-            minutes: Minutes,
-            hours: Hours,
-            days_of_month: DaysOfMonth,
-            months: Months,
-            days_of_week: DaysOfWeek,
-            years: Years)
+    fn from(seconds: Option<Seconds>,
+            minutes: Option<Minutes>,
+            hours: Option<Hours>,
+            days_of_month: Option<DaysOfMonth>,
+            months: Option<Months>,
+            days_of_week: Option<DaysOfWeek>,
+            years: Option<Years>)
             -> Schedule {
         Schedule {
             years: years,
@@ -379,13 +379,13 @@ named!(shorthand_yearly <Schedule>,
   do_parse!(
     tag!("@yearly") >>
     (Schedule::from(
-      Seconds::from_ordinal(0),
-      Minutes::from_ordinal(0),
-      Hours::from_ordinal(0),
-      DaysOfMonth::from_ordinal(1),
-      Months::from_ordinal(1),
-      DaysOfWeek::all(),
-      Years::all()
+      Some(Seconds::from_ordinal(0)),
+      Some(Minutes::from_ordinal(0)),
+      Some(Hours::from_ordinal(0)),
+      Some(DaysOfMonth::from_ordinal(1)),
+      Some(Months::from_ordinal(1)),
+      None,
+      None,
     ))
   )
 );
@@ -394,13 +394,13 @@ named!(shorthand_monthly <Schedule>,
   do_parse!(
     tag!("@monthly") >>
     (Schedule::from(
-      Seconds::from_ordinal_set(iter::once(0).collect()),
-      Minutes::from_ordinal_set(iter::once(0).collect()),
-      Hours::from_ordinal_set(iter::once(0).collect()),
-      DaysOfMonth::from_ordinal_set(iter::once(1).collect()),
-      Months::all(),
-      DaysOfWeek::all(),
-      Years::all()
+      Some(Seconds::from_ordinal(0)),
+      Some(Minutes::from_ordinal(0)),
+      Some(Hours::from_ordinal(0)),
+      Some(DaysOfMonth::from_ordinal(1)),
+      None,
+      None,
+      None,
     ))
   )
 );
@@ -409,13 +409,13 @@ named!(shorthand_weekly <Schedule>,
   do_parse!(
     tag!("@weekly") >>
     (Schedule::from(
-      Seconds::from_ordinal_set(iter::once(0).collect()),
-      Minutes::from_ordinal_set(iter::once(0).collect()),
-      Hours::from_ordinal_set(iter::once(0).collect()),
-      DaysOfMonth::all(),
-      Months::all(),
-      DaysOfWeek::from_ordinal_set(iter::once(1).collect()),
-      Years::all()
+      Some(Seconds::from_ordinal(0)),
+      Some(Minutes::from_ordinal(0)),
+      Some(Hours::from_ordinal(0)),
+      None,
+      None,
+      Some(DaysOfWeek::from_ordinal(1)),
+      None,
     ))
   )
 );
@@ -424,13 +424,13 @@ named!(shorthand_daily <Schedule>,
   do_parse!(
     tag!("@daily") >>
     (Schedule::from(
-      Seconds::from_ordinal_set(iter::once(0).collect()),
-      Minutes::from_ordinal_set(iter::once(0).collect()),
-      Hours::from_ordinal_set(iter::once(0).collect()),
-      DaysOfMonth::all(),
-      Months::all(),
-      DaysOfWeek::all(),
-      Years::all()
+      Some(Seconds::from_ordinal(0)),
+      Some(Minutes::from_ordinal(0)),
+      Some(Hours::from_ordinal(0)),
+      None,
+      None,
+      None,
+      None,
     ))
   )
 );
@@ -439,13 +439,13 @@ named!(shorthand_hourly <Schedule>,
   do_parse!(
     tag!("@hourly") >>
     (Schedule::from(
-      Seconds::from_ordinal_set(iter::once(0).collect()),
-      Minutes::from_ordinal_set(iter::once(0).collect()),
-      Hours::all(),
-      DaysOfMonth::all(),
-      Months::all(),
-      DaysOfWeek::all(),
-      Years::all()
+      Some(Seconds::from_ordinal(0)),
+      Some(Minutes::from_ordinal(0)),
+      None,
+      None,
+      None,
+      None,
+      None,
     ))
   )
 );

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -9,13 +9,13 @@ use std::iter::{self, Iterator};
 use time_unit::*;
 
 pub struct Schedule {
-    years: Years,
-    days_of_week: DaysOfWeek,
-    months: Months,
-    days_of_month: DaysOfMonth,
-    hours: Hours,
-    minutes: Minutes,
-    seconds: Seconds,
+    years: Option<Years>,
+    days_of_week: Option<DaysOfWeek>,
+    months: Option<Months>,
+    days_of_month: Option<DaysOfMonth>,
+    hours: Option<Hours>,
+    minutes: Option<Minutes>,
+    seconds: Option<Seconds>,
 }
 
 impl Schedule {

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -34,16 +34,18 @@ impl Schedule {
         let days_of_month = DaysOfMonth::from_field(iter.next().unwrap())?;
         let months = Months::from_field(iter.next().unwrap())?;
         let days_of_week = DaysOfWeek::from_field(iter.next().unwrap())?;
-        let years: Years = iter.next().map(Years::from_field).unwrap_or_else(|| Ok(Years::all()))?;
+        let years: Option<Years> = match iter.next() {
+            Some(f) => Years::from_field(f)?,
+            None => None
+        };
 
-        //TODO: Remove Some(...)
-        Ok(Schedule::from(Some(seconds),
-                        Some(minutes),
-                        Some(hours),
-                        Some(days_of_month),
-                        Some(months),
-                        Some(days_of_week),
-                        Some(years)))
+        Ok(Schedule::from(seconds,
+                          minutes,
+                          hours,
+                          days_of_month,
+                          months,
+                          days_of_week,
+                          years,))
     }
 
     fn from(seconds: Option<Seconds>,

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -497,208 +497,211 @@ fn days_in_month(month: Ordinal, year: Ordinal) -> u32 {
         _ => 31,
     }
 }
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[test]
+    fn test_next_after() {
+        let expression = "0 5,13,40-42 17 1 Jan *";
+        let schedule = schedule(expression.as_bytes());
+        assert!(schedule.is_done());
+        let schedule = schedule.unwrap().1;
+        let next = schedule.next_after(&UTC::now());
+        println!("NEXT AFTER for {} {:?}", expression, next);
+        assert!(next.is_some());
+    }
 
-#[test]
-fn test_next_after() {
-    let expression = "0 5,13,40-42 17 1 Jan *";
-    let schedule = schedule(expression.as_bytes());
-    assert!(schedule.is_done());
-    let schedule = schedule.unwrap().1;
-    let next = schedule.next_after(&UTC::now());
-    println!("NEXT AFTER for {} {:?}", expression, next);
-    assert!(next.is_some());
-}
+    #[test]
+    fn test_upcoming_utc() {
+        let expression = "0 0,30 0,6,12,18 1,15 Jan-March Thurs";
+        let schedule = schedule(expression.as_bytes());
+        assert!(schedule.is_done());
+        let schedule = schedule.unwrap().1;
+        let mut upcoming = schedule.upcoming(UTC);
+        let next1 = upcoming.next();
+        assert!(next1.is_some());
+        let next2 = upcoming.next();
+        assert!(next2.is_some());
+        let next3 = upcoming.next();
+        assert!(next3.is_some());
+        println!("Upcoming 1 for {} {:?}", expression, next1);
+        println!("Upcoming 2 for {} {:?}", expression, next2);
+        println!("Upcoming 3 for {} {:?}", expression, next3);
+    }
 
-#[test]
-fn test_upcoming_utc() {
-    let expression = "0 0,30 0,6,12,18 1,15 Jan-March Thurs";
-    let schedule = schedule(expression.as_bytes());
-    assert!(schedule.is_done());
-    let schedule = schedule.unwrap().1;
-    let mut upcoming = schedule.upcoming(UTC);
-    let next1 = upcoming.next();
-    assert!(next1.is_some());
-    let next2 = upcoming.next();
-    assert!(next2.is_some());
-    let next3 = upcoming.next();
-    assert!(next3.is_some());
-    println!("Upcoming 1 for {} {:?}", expression, next1);
-    println!("Upcoming 2 for {} {:?}", expression, next2);
-    println!("Upcoming 3 for {} {:?}", expression, next3);
-}
-
-#[test]
-fn test_upcoming_local() {
-    use chrono::Local;
-    let expression = "0 0,30 0,6,12,18 1,15 Jan-March Thurs";
-    let schedule = schedule(expression.as_bytes());
-    assert!(schedule.is_done());
-    let schedule = schedule.unwrap().1;
-    let mut upcoming = schedule.upcoming(Local);
-    let next1 = upcoming.next();
-    assert!(next1.is_some());
-    let next2 = upcoming.next();
-    assert!(next2.is_some());
-    let next3 = upcoming.next();
-    assert!(next3.is_some());
-    println!("Upcoming 1 for {} {:?}", expression, next1);
-    println!("Upcoming 2 for {} {:?}", expression, next2);
-    println!("Upcoming 3 for {} {:?}", expression, next3);
-}
+    #[test]
+    fn test_upcoming_local() {
+        use chrono::Local;
+        let expression = "0 0,30 0,6,12,18 1,15 Jan-March Thurs";
+        let schedule = schedule(expression.as_bytes());
+        assert!(schedule.is_done());
+        let schedule = schedule.unwrap().1;
+        let mut upcoming = schedule.upcoming(Local);
+        let next1 = upcoming.next();
+        assert!(next1.is_some());
+        let next2 = upcoming.next();
+        assert!(next2.is_some());
+        let next3 = upcoming.next();
+        assert!(next3.is_some());
+        println!("Upcoming 1 for {} {:?}", expression, next1);
+        println!("Upcoming 2 for {} {:?}", expression, next2);
+        println!("Upcoming 3 for {} {:?}", expression, next3);
+    }
 
 
-#[test]
-fn test_valid_from_str() {
-    let schedule = Schedule::from_str("0 0,30 0,6,12,18 1,15 Jan-March Thurs");
-    assert!(schedule.is_ok());
-}
+    #[test]
+    fn test_valid_from_str() {
+        let schedule = Schedule::from_str("0 0,30 0,6,12,18 1,15 Jan-March Thurs");
+        assert!(schedule.is_ok());
+    }
 
-#[test]
-fn test_invalid_from_str() {
-    let schedule = Schedule::from_str("cheesecake 0,30 0,6,12,18 1,15 Jan-March Thurs");
-    assert!(schedule.is_err());
-}
+    #[test]
+    fn test_invalid_from_str() {
+        let schedule = Schedule::from_str("cheesecake 0,30 0,6,12,18 1,15 Jan-March Thurs");
+        assert!(schedule.is_err());
+    }
 
-#[test]
-fn test_nom_valid_number() {
-    let expression = "1997";
-    assert!(point(expression.as_bytes()).is_done());
-}
+    #[test]
+    fn test_nom_valid_number() {
+        let expression = "1997";
+        assert!(point(expression.as_bytes()).is_done());
+    }
 
-#[test]
-fn test_nom_invalid_point() {
-    let expression = "a";
-    assert!(point(expression.as_bytes()).is_err());
-}
+    #[test]
+    fn test_nom_invalid_point() {
+        let expression = "a";
+        assert!(point(expression.as_bytes()).is_err());
+    }
 
-#[test]
-fn test_nom_valid_named_point() {
-    let expression = "WED";
-    assert!(named_point(expression.as_bytes()).is_done());
-}
+    #[test]
+    fn test_nom_valid_named_point() {
+        let expression = "WED";
+        assert!(named_point(expression.as_bytes()).is_done());
+    }
 
-#[test]
-fn test_nom_invalid_named_point() {
-    let expression = "8";
-    assert!(named_point(expression.as_bytes()).is_err());
-}
+    #[test]
+    fn test_nom_invalid_named_point() {
+        let expression = "8";
+        assert!(named_point(expression.as_bytes()).is_err());
+    }
 
-#[test]
-fn test_nom_valid_period() {
-    let expression = "1/2";
-    assert!(period(expression.as_bytes()).is_done());
-}
+    #[test]
+    fn test_nom_valid_period() {
+        let expression = "1/2";
+        assert!(period(expression.as_bytes()).is_done());
+    }
 
-#[test]
-fn test_nom_invalid_period() {
-    let expression = "Wed/4";
-    assert!(period(expression.as_bytes()).is_err());
-}
+    #[test]
+    fn test_nom_invalid_period() {
+        let expression = "Wed/4";
+        assert!(period(expression.as_bytes()).is_err());
+    }
 
-#[test]
-fn test_nom_valid_number_list() {
-    let expression = "1,2";
-    assert!(field(expression.as_bytes()).is_done());
-}
+    #[test]
+    fn test_nom_valid_number_list() {
+        let expression = "1,2";
+        assert!(field(expression.as_bytes()).is_done());
+    }
 
-#[test]
-fn test_nom_invalid_number_list() {
-    let expression = ",1,2";
-    assert!(field(expression.as_bytes()).is_err());
-}
+    #[test]
+    fn test_nom_invalid_number_list() {
+        let expression = ",1,2";
+        assert!(field(expression.as_bytes()).is_err());
+    }
 
-#[test]
-fn test_nom_valid_range_field() {
-    let expression = "1-4";
-    assert!(range(expression.as_bytes()).is_done());
-}
+    #[test]
+    fn test_nom_valid_range_field() {
+        let expression = "1-4";
+        assert!(range(expression.as_bytes()).is_done());
+    }
 
-#[test]
-fn test_nom_invalid_range_field() {
-    let expression = "-4";
-    assert!(range(expression.as_bytes()).is_err());
-}
+    #[test]
+    fn test_nom_invalid_range_field() {
+        let expression = "-4";
+        assert!(range(expression.as_bytes()).is_err());
+    }
 
-#[test]
-fn test_nom_valid_named_range_field() {
-    let expression = "TUES-THURS";
-    assert!(named_range(expression.as_bytes()).is_done());
-}
+    #[test]
+    fn test_nom_valid_named_range_field() {
+        let expression = "TUES-THURS";
+        assert!(named_range(expression.as_bytes()).is_done());
+    }
 
-#[test]
-fn test_nom_invalid_named_range_field() {
-    let expression = "3-THURS";
-    assert!(named_range(expression.as_bytes()).is_err());
-}
+    #[test]
+    fn test_nom_invalid_named_range_field() {
+        let expression = "3-THURS";
+        assert!(named_range(expression.as_bytes()).is_err());
+    }
 
-#[test]
-fn test_nom_valid_schedule() {
-    let expression = "* * * * * *";
-    assert!(schedule(expression.as_bytes()).is_done());
-}
+    #[test]
+    fn test_nom_valid_schedule() {
+        let expression = "* * * * * *";
+        assert!(schedule(expression.as_bytes()).is_done());
+    }
 
-#[test]
-fn test_nom_invalid_schedule() {
-    let expression = "* * * *";
-    assert!(schedule(expression.as_bytes()).is_err());
-}
+    #[test]
+    fn test_nom_invalid_schedule() {
+        let expression = "* * * *";
+        assert!(schedule(expression.as_bytes()).is_err());
+    }
 
-#[test]
-fn test_nom_valid_seconds_list() {
-    let expression = "0,20,40 * * * * *";
-    assert!(schedule(expression.as_bytes()).is_done());
-}
+    #[test]
+    fn test_nom_valid_seconds_list() {
+        let expression = "0,20,40 * * * * *";
+        assert!(schedule(expression.as_bytes()).is_done());
+    }
 
-#[test]
-fn test_nom_valid_seconds_range() {
-    let expression = "0-40 * * * * *";
-    assert!(schedule(expression.as_bytes()).is_done());
-}
+    #[test]
+    fn test_nom_valid_seconds_range() {
+        let expression = "0-40 * * * * *";
+        assert!(schedule(expression.as_bytes()).is_done());
+    }
 
-#[test]
-fn test_nom_valid_seconds_mix() {
-    let expression = "0-5,58 * * * * *";
-    assert!(schedule(expression.as_bytes()).is_done());
-}
+    #[test]
+    fn test_nom_valid_seconds_mix() {
+        let expression = "0-5,58 * * * * *";
+        assert!(schedule(expression.as_bytes()).is_done());
+    }
 
-#[test]
-fn test_nom_invalid_seconds_range() {
-    let expression = "0-65 * * * * *";
-    assert!(schedule(expression.as_bytes()).is_err());
-}
+    #[test]
+    fn test_nom_invalid_seconds_range() {
+        let expression = "0-65 * * * * *";
+        assert!(schedule(expression.as_bytes()).is_err());
+    }
 
-#[test]
-fn test_nom_invalid_seconds_list() {
-    let expression = "103,12 * * * * *";
-    assert!(schedule(expression.as_bytes()).is_err());
-}
+    #[test]
+    fn test_nom_invalid_seconds_list() {
+        let expression = "103,12 * * * * *";
+        assert!(schedule(expression.as_bytes()).is_err());
+    }
 
-#[test]
-fn test_nom_invalid_seconds_mix() {
-    let expression = "0-5,102 * * * * *";
-    assert!(schedule(expression.as_bytes()).is_err());
-}
+    #[test]
+    fn test_nom_invalid_seconds_mix() {
+        let expression = "0-5,102 * * * * *";
+        assert!(schedule(expression.as_bytes()).is_err());
+    }
 
-#[test]
-fn test_nom_valid_days_of_week_list() {
-    let expression = "* * * * * MON,WED,FRI";
-    assert!(schedule(expression.as_bytes()).is_done());
-}
+    #[test]
+    fn test_nom_valid_days_of_week_list() {
+        let expression = "* * * * * MON,WED,FRI";
+        assert!(schedule(expression.as_bytes()).is_done());
+    }
 
-#[test]
-fn test_nom_invalid_days_of_week_list() {
-    let expression = "* * * * * MON,TURTLE";
-    assert!(schedule(expression.as_bytes()).is_err());
-}
+    #[test]
+    fn test_nom_invalid_days_of_week_list() {
+        let expression = "* * * * * MON,TURTLE";
+        assert!(schedule(expression.as_bytes()).is_err());
+    }
 
-#[test]
-fn test_nom_valid_days_of_week_range() {
-    let expression = "* * * * * MON-FRI";
-    assert!(schedule(expression.as_bytes()).is_done());
-}
+    #[test]
+    fn test_nom_valid_days_of_week_range() {
+        let expression = "* * * * * MON-FRI";
+        assert!(schedule(expression.as_bytes()).is_done());
+    }
 
-#[test]
-fn test_nom_invalid_days_of_week_range() {
-    let expression = "* * * * * BEAR-OWL";
-    assert!(schedule(expression.as_bytes()).is_err());
+    #[test]
+    fn test_nom_invalid_days_of_week_range() {
+        let expression = "* * * * * BEAR-OWL";
+        assert!(schedule(expression.as_bytes()).is_err());
+    }
 }

--- a/src/time_unit/mod.rs
+++ b/src/time_unit/mod.rs
@@ -67,7 +67,7 @@ pub trait TimeUnitField
         use std::convert::TryInto;
         //println!("ordinals_from_specifier for {} => {:?}", Self::name(), specifier);
         match *specifier {
-            All => Ok(Self::supported_ordinals()),
+            All => Err(ExpressionError(String::from("This should never happen"))), //TODO: Descriptive error
             Point(ordinal) => Ok((&[ordinal]).iter().cloned().collect()),
             NamedPoint(ref name) => {
                 Ok((&[Self::ordinal_from_name(name)?]).iter().cloned().collect())

--- a/src/time_unit/mod.rs
+++ b/src/time_unit/mod.rs
@@ -64,6 +64,7 @@ pub trait TimeUnitField
 
     fn ordinals_from_specifier(specifier: &Specifier) -> Result<OrdinalSet, ExpressionError> {
         use self::Specifier::*;
+        use std::convert::TryInto;
         //println!("ordinals_from_specifier for {} => {:?}", Self::name(), specifier);
         match *specifier {
             All => Ok(Self::supported_ordinals()),
@@ -73,7 +74,7 @@ pub trait TimeUnitField
             }
             Period(start, step) => {
                 let start = Self::validate_ordinal(start)?;
-                Ok((start..Self::inclusive_max() + 1).step_by(step).collect())
+                Ok((start..Self::inclusive_max() + 1).step_by(step.try_into().unwrap()).collect())
             }
             Range(start, end) => {
                 match (Self::validate_ordinal(start), Self::validate_ordinal(end)) {


### PR DESCRIPTION
Everytime a cron is created with an * specifier, then the field in Schedule is populated with a set of all possibilities (save year, because those possibilities are endless). I thought that maybe it was a better idea to store None, and only create those possibilities on demand.