### PR TITLE
Change Fields in Schedule struct to Option<_> types

### DIFF
--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -742,22 +742,24 @@ where
     Self: Sized,
 {
     //TODO: Replace with std::convert::TryFrom when stable
-    fn from_field(field: Field) -> Result<Self, Error>;
+    fn from_field(field: Field) -> Result<Option<Self>, Error>;
 }
 
 impl<T> FromField for T
 where
     T: TimeUnitField,
 {
-    fn from_field(field: Field) -> Result<T, Error> {
+    fn from_field(field: Field) -> Result<Option<T>, Error> {
+
         let mut ordinals = OrdinalSet::new(); // TODO:Combinator
         for specifier in field.specifiers {
+            if specifier == RootSpecifier::Specifier(Specifier::All) { return Ok(None); }
             let specifier_ordinals: OrdinalSet = T::ordinals_from_root_specifier(&specifier)?;
             for ordinal in specifier_ordinals {
                 ordinals.insert(T::validate_ordinal(ordinal)?);
             }
         }
-        Ok(T::from_ordinal_set(ordinals))
+        Ok(Some(T::from_ordinal_set(ordinals)))
     }
 }
 
@@ -867,80 +869,80 @@ named!(
 named!(
     shorthand_yearly<Input, Schedule>,
     do_parse!(
-        tag!("@yearly")
-            >> (Schedule::from(
-                Seconds::from_ordinal(0),
-                Minutes::from_ordinal(0),
-                Hours::from_ordinal(0),
-                DaysOfMonth::from_ordinal(1),
-                Months::from_ordinal(1),
-                DaysOfWeek::all(),
-                Years::all()
-            ))
+        tag!("@yearly") >>
+        (Schedule::from(
+        Some(Seconds::from_ordinal(0)),
+        Some(Minutes::from_ordinal(0)),
+        Some(Hours::from_ordinal(0)),
+        Some(DaysOfMonth::from_ordinal(1)),
+        Some(Months::from_ordinal(1)),
+        None,
+        None,
+        ))
     )
 );
 
 named!(
     shorthand_monthly<Input, Schedule>,
     do_parse!(
-        tag!("@monthly")
-            >> (Schedule::from(
-                Seconds::from_ordinal_set(iter::once(0).collect()),
-                Minutes::from_ordinal_set(iter::once(0).collect()),
-                Hours::from_ordinal_set(iter::once(0).collect()),
-                DaysOfMonth::from_ordinal_set(iter::once(1).collect()),
-                Months::all(),
-                DaysOfWeek::all(),
-                Years::all()
-            ))
+        tag!("@monthly") >>
+        (Schedule::from(
+        Some(Seconds::from_ordinal(0)),
+        Some(Minutes::from_ordinal(0)),
+        Some(Hours::from_ordinal(0)),
+        Some(DaysOfMonth::from_ordinal(1)),
+        None,
+        None,
+        None,
+        ))
     )
 );
 
 named!(
     shorthand_weekly<Input, Schedule>,
     do_parse!(
-        tag!("@weekly")
-            >> (Schedule::from(
-                Seconds::from_ordinal_set(iter::once(0).collect()),
-                Minutes::from_ordinal_set(iter::once(0).collect()),
-                Hours::from_ordinal_set(iter::once(0).collect()),
-                DaysOfMonth::all(),
-                Months::all(),
-                DaysOfWeek::from_ordinal_set(iter::once(1).collect()),
-                Years::all()
-            ))
+        tag!("@weekly") >>
+        (Schedule::from(
+        Some(Seconds::from_ordinal(0)),
+        Some(Minutes::from_ordinal(0)),
+        Some(Hours::from_ordinal(0)),
+        None,
+        None,
+        Some(DaysOfWeek::from_ordinal(1)),
+        None,
+        ))
     )
 );
 
 named!(
     shorthand_daily<Input, Schedule>,
     do_parse!(
-        tag!("@daily")
-            >> (Schedule::from(
-                Seconds::from_ordinal_set(iter::once(0).collect()),
-                Minutes::from_ordinal_set(iter::once(0).collect()),
-                Hours::from_ordinal_set(iter::once(0).collect()),
-                DaysOfMonth::all(),
-                Months::all(),
-                DaysOfWeek::all(),
-                Years::all()
-            ))
+        tag!("@daily") >>
+        (Schedule::from(
+        Some(Seconds::from_ordinal(0)),
+        Some(Minutes::from_ordinal(0)),
+        Some(Hours::from_ordinal(0)),
+        None,
+        None,
+        None,
+        None,
+        ))
     )
 );
 
 named!(
     shorthand_hourly<Input, Schedule>,
     do_parse!(
-        tag!("@hourly")
-            >> (Schedule::from(
-                Seconds::from_ordinal_set(iter::once(0).collect()),
-                Minutes::from_ordinal_set(iter::once(0).collect()),
-                Hours::all(),
-                DaysOfMonth::all(),
-                Months::all(),
-                DaysOfWeek::all(),
-                Years::all()
-            ))
+        tag!("@hourly") >>
+        (Schedule::from(
+        Some(Seconds::from_ordinal(0)),
+        Some(Minutes::from_ordinal(0)),
+        None,
+        None,
+        None,
+        None,
+        None,
+        ))
     )
 );
 

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -5,7 +5,7 @@ use nom::{types::CompleteStr as Input, *};
 use std::collections::BTreeSet;
 use std::collections::Bound::{Included, Unbounded};
 use std::fmt::{Display, Formatter, Result as FmtResult};
-use std::iter::{self, Iterator};
+use std::iter::{Iterator};
 use std::str::{self, FromStr};
 
 use crate::time_unit::*;
@@ -530,44 +530,44 @@ impl Schedule {
 
     /// Returns a [TimeUnitSpec](trait.TimeUnitSpec.html) describing the years included
     /// in this [Schedule](struct.Schedule.html).
-    pub fn years(&self) -> &Years {
-        &self.years.as_ref().unwrap_or(&Years::all())
+    pub fn years(&self) -> Years {
+        self.years.clone().unwrap_or(Years::all())
     }
 
     /// Returns a [TimeUnitSpec](trait.TimeUnitSpec.html) describing the months of the year included
     /// in this [Schedule](struct.Schedule.html).
-    pub fn months(&self) -> &Months  {
-        &self.months.as_ref().unwrap_or(&Months::all())
+    pub fn months(&self) -> Months  {
+        self.months.clone().unwrap_or(Months::all())
     }
 
     /// Returns a [TimeUnitSpec](trait.TimeUnitSpec.html) describing the days of the month included
     /// in this [Schedule](struct.Schedule.html).
-    pub fn days_of_month(&self) -> &DaysOfMonth  {
-        &self.days_of_month.as_ref().unwrap_or(&DaysOfMonth::all())
+    pub fn days_of_month(&self) -> DaysOfMonth  {
+        self.days_of_month.clone().unwrap_or(DaysOfMonth::all())
     }
 
     /// Returns a [TimeUnitSpec](trait.TimeUnitSpec.html) describing the days of the week included
     /// in this [Schedule](struct.Schedule.html).
-    pub fn days_of_week(&self) -> &DaysOfWeek {
-        &self.days_of_week.as_ref().unwrap_or(&DaysOfWeek::all())
+    pub fn days_of_week(&self) -> DaysOfWeek {
+        self.days_of_week.clone().unwrap_or(DaysOfWeek::all())
     }
 
     /// Returns a [TimeUnitSpec](trait.TimeUnitSpec.html) describing the hours of the day included
     /// in this [Schedule](struct.Schedule.html).
-    pub fn hours(&self) -> &Hours {
-        &self.hours.as_ref().unwrap_or(&Hours::all())
+    pub fn hours(&self) -> Hours {
+        self.hours.clone().unwrap_or(Hours::all())
     }
 
     /// Returns a [TimeUnitSpec](trait.TimeUnitSpec.html) describing the minutes of the hour included
     /// in this [Schedule](struct.Schedule.html).
-    pub fn minutes(&self) -> &Minutes {
-        &self.minutes.as_ref().unwrap_or(&Minutes::all())
+    pub fn minutes(&self) -> Minutes {
+        self.minutes.clone().unwrap_or(Minutes::all())
     }
 
     /// Returns a [TimeUnitSpec](trait.TimeUnitSpec.html) describing the seconds of the minute included
     /// in this [Schedule](struct.Schedule.html).
-    pub fn seconds(&self) -> &Seconds {
-        &self.seconds.as_ref().unwrap_or(&Seconds::all())
+    pub fn seconds(&self) -> Seconds {
+        self.seconds.clone().unwrap_or(Seconds::all())
     }
 
     /// Returns an Option of [TimeUnitSpec](trait.TimeUnitSpec.html) describing the years included

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -567,6 +567,45 @@ impl Schedule {
     /// Returns a [TimeUnitSpec](trait.TimeUnitSpec.html) describing the seconds of the minute included
     /// in this [Schedule](struct.Schedule.html).
     pub fn seconds(&self) -> &impl TimeUnitSpec {
+    /// Returns an Option of [TimeUnitSpec](trait.TimeUnitSpec.html) describing the years included
+    /// in this [Schedule](struct.Schedule.html), or None if they where unspecified.
+    pub fn years_or_unspecified(&self) -> &Option<Years> {
+        &self.years
+    }
+
+    /// Returns an Option of [TimeUnitSpec](trait.TimeUnitSpec.html) describing the months of the year included
+    /// in this [Schedule](struct.Schedule.html), or None if they where unspecified.
+    pub fn months_or_unspecified(&self) -> &Option<Months>  {
+        &self.months
+    }
+
+    /// Returns an Option of [TimeUnitSpec](trait.TimeUnitSpec.html) describing the days of the month included
+    /// in this [Schedule](struct.Schedule.html), or None if they where unspecified.
+    pub fn days_of_month_or_unspecified(&self) -> &Option<DaysOfMonth>  {
+        &self.days_of_month
+    }
+
+    /// Returns an Option of [TimeUnitSpec](trait.TimeUnitSpec.html) describing the days of the week included
+    /// in this [Schedule](struct.Schedule.html), or None if they where unspecified.
+    pub fn days_of_week_or_unspecified(&self) -> &Option<DaysOfWeek> {
+        &self.days_of_week
+    }
+
+    /// Returns an Option of [TimeUnitSpec](trait.TimeUnitSpec.html) describing the hours of the day included
+    /// in this [Schedule](struct.Schedule.html), or None if they where unspecified.
+    pub fn hours_or_unspecified(&self) -> &Option<Hours> {
+        &self.hours
+    }
+
+    /// Returns an Option of [TimeUnitSpec](trait.TimeUnitSpec.html) describing the minutes of the hour included
+    /// in this [Schedule](struct.Schedule.html), or None if they where unspecified.
+    pub fn minutes_or_unspecified(&self) -> &Option<Minutes> {
+        &self.minutes
+    }
+
+    /// Returns an Option of [TimeUnitSpec](trait.TimeUnitSpec.html) describing the seconds of the minute included
+    /// in this [Schedule](struct.Schedule.html), or None if they where unspecified.
+    pub fn seconds_or_unspecified(&self) -> &Option<Seconds> {
         &self.seconds
     }
 }

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -530,43 +530,46 @@ impl Schedule {
 
     /// Returns a [TimeUnitSpec](trait.TimeUnitSpec.html) describing the years included
     /// in this [Schedule](struct.Schedule.html).
-    pub fn years(&self) -> &impl TimeUnitSpec {
-        &self.years
+    pub fn years(&self) -> &Years {
+        &self.years.as_ref().unwrap_or(&Years::all())
     }
 
     /// Returns a [TimeUnitSpec](trait.TimeUnitSpec.html) describing the months of the year included
     /// in this [Schedule](struct.Schedule.html).
-    pub fn months(&self) -> &impl TimeUnitSpec {
-        &self.months
+    pub fn months(&self) -> &Months  {
+        &self.months.as_ref().unwrap_or(&Months::all())
     }
 
     /// Returns a [TimeUnitSpec](trait.TimeUnitSpec.html) describing the days of the month included
     /// in this [Schedule](struct.Schedule.html).
-    pub fn days_of_month(&self) -> &impl TimeUnitSpec {
-        &self.days_of_month
+    pub fn days_of_month(&self) -> &DaysOfMonth  {
+        &self.days_of_month.as_ref().unwrap_or(&DaysOfMonth::all())
     }
 
     /// Returns a [TimeUnitSpec](trait.TimeUnitSpec.html) describing the days of the week included
     /// in this [Schedule](struct.Schedule.html).
-    pub fn days_of_week(&self) -> &impl TimeUnitSpec {
-        &self.days_of_week
+    pub fn days_of_week(&self) -> &DaysOfWeek {
+        &self.days_of_week.as_ref().unwrap_or(&DaysOfWeek::all())
     }
 
     /// Returns a [TimeUnitSpec](trait.TimeUnitSpec.html) describing the hours of the day included
     /// in this [Schedule](struct.Schedule.html).
-    pub fn hours(&self) -> &impl TimeUnitSpec {
-        &self.hours
+    pub fn hours(&self) -> &Hours {
+        &self.hours.as_ref().unwrap_or(&Hours::all())
     }
 
     /// Returns a [TimeUnitSpec](trait.TimeUnitSpec.html) describing the minutes of the hour included
     /// in this [Schedule](struct.Schedule.html).
-    pub fn minutes(&self) -> &impl TimeUnitSpec {
-        &self.minutes
+    pub fn minutes(&self) -> &Minutes {
+        &self.minutes.as_ref().unwrap_or(&Minutes::all())
     }
 
     /// Returns a [TimeUnitSpec](trait.TimeUnitSpec.html) describing the seconds of the minute included
     /// in this [Schedule](struct.Schedule.html).
-    pub fn seconds(&self) -> &impl TimeUnitSpec {
+    pub fn seconds(&self) -> &Seconds {
+        &self.seconds.as_ref().unwrap_or(&Seconds::all())
+    }
+
     /// Returns an Option of [TimeUnitSpec](trait.TimeUnitSpec.html) describing the years included
     /// in this [Schedule](struct.Schedule.html), or None if they where unspecified.
     pub fn years_or_unspecified(&self) -> &Option<Years> {

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -13,13 +13,13 @@ use crate::time_unit::*;
 #[derive(Clone, Debug)]
 pub struct Schedule {
     source: Option<String>,
-    years: Years,
-    days_of_week: DaysOfWeek,
-    months: Months,
-    days_of_month: DaysOfMonth,
-    hours: Hours,
-    minutes: Minutes,
-    seconds: Seconds,
+    years: Option<Years>,
+    days_of_week: Option<DaysOfWeek>,
+    months: Option<Months>,
+    days_of_month: Option<DaysOfMonth>,
+    hours: Option<Hours>,
+    minutes: Option<Minutes>,
+    seconds: Option<Seconds>,
 }
 
 struct NextAfterQuery<Z>
@@ -236,10 +236,10 @@ impl Schedule {
         let days_of_month = DaysOfMonth::from_field(iter.next().unwrap())?;
         let months = Months::from_field(iter.next().unwrap())?;
         let days_of_week = DaysOfWeek::from_field(iter.next().unwrap())?;
-        let years: Years = iter
-            .next()
-            .map(Years::from_field)
-            .unwrap_or_else(|| Ok(Years::all()))?;
+        let years = match iter.next() {
+            Some(f) => Years::from_field(f)?,
+            None => None
+        };
 
         Ok(Schedule::from(
             seconds,
@@ -253,13 +253,13 @@ impl Schedule {
     }
 
     fn from(
-        seconds: Seconds,
-        minutes: Minutes,
-        hours: Hours,
-        days_of_month: DaysOfMonth,
-        months: Months,
-        days_of_week: DaysOfWeek,
-        years: Years,
+        seconds: Option<Seconds>,
+        minutes: Option<Minutes>,
+        hours: Option<Hours>,
+        days_of_month: Option<DaysOfMonth>,
+        months: Option<Months>,
+        days_of_week: Option<DaysOfWeek>,
+        years: Option<Years>
     ) -> Schedule {
         Schedule {
             source: None,


### PR DESCRIPTION
I was working on a program that needed to know if a specific field was actually specified. I thought it would also be more memory efficient to actually store smaller options, and return TimeUnitSpec::all() when it's needed, instead of storing it.

I'm still having some problems with the implementation. The Schedule::years() function (etc.) aren't returning properly. I'm still having some personal problems with understanding Rusts inner workings.