### PR TITLE
Refactor monolithic schedule.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ extern crate chrono_tz;
 pub mod error;
 mod schedule;
 mod time_unit;
+mod ordinal;
 
 pub use crate::schedule::Schedule;
 pub use crate::time_unit::TimeUnitSpec;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ pub mod error;
 mod schedule;
 mod time_unit;
 mod ordinal;
+mod specifier;
 
 pub use crate::schedule::Schedule;
 pub use crate::time_unit::TimeUnitSpec;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@ mod schedule;
 mod time_unit;
 mod ordinal;
 mod specifier;
+mod queries;
 
 pub use crate::schedule::Schedule;
 pub use crate::time_unit::TimeUnitSpec;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@ mod time_unit;
 mod ordinal;
 mod specifier;
 mod queries;
+mod parsing;
 
 pub use crate::schedule::Schedule;
 pub use crate::time_unit::TimeUnitSpec;

--- a/src/ordinal.rs
+++ b/src/ordinal.rs
@@ -1,0 +1,8 @@
+use std::collections::BTreeSet;
+
+pub type Ordinal = u32;
+// TODO: Make OrdinalSet an enum.
+// It should either be a BTreeSet of ordinals or an `All` option to save space.
+// `All` can iterate from inclusive_min to inclusive_max and answer membership
+// queries
+pub type OrdinalSet = BTreeSet<Ordinal>;

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -1,0 +1,665 @@
+use nom::{types::CompleteStr as Input, *};
+use std::iter::{self, Iterator};
+use std::str::{self, FromStr};
+
+use crate::error::{Error, ErrorKind};
+use crate::schedule::Schedule;
+use crate::specifier::*;
+use crate::time_unit::*;
+use crate::ordinal::*;
+
+impl FromStr for Schedule {
+    type Err = Error;
+    fn from_str(expression: &str) -> Result<Self, Self::Err> {
+        match schedule(Input(expression)) {
+            Ok((_, mut schedule)) => {
+                schedule.source.replace(expression.to_owned());
+                Ok(schedule)
+            } // Extract from nom tuple
+            Err(_) => Err(ErrorKind::Expression("Invalid cron expression.".to_owned()).into()), //TODO: Details
+        }
+    }
+}
+
+impl Schedule {
+    fn from_field_list(fields: Vec<Field>) -> Result<Schedule, Error> {
+        let number_of_fields = fields.len();
+        if number_of_fields != 6 && number_of_fields != 7 {
+            return Err(ErrorKind::Expression(format!(
+                "Expression has {} fields. Valid cron \
+                 expressions have 6 or 7.",
+                number_of_fields
+            ))
+            .into());
+        }
+
+        let mut iter = fields.into_iter();
+
+        let seconds = Seconds::from_field(iter.next().unwrap())?;
+        let minutes = Minutes::from_field(iter.next().unwrap())?;
+        let hours = Hours::from_field(iter.next().unwrap())?;
+        let days_of_month = DaysOfMonth::from_field(iter.next().unwrap())?;
+        let months = Months::from_field(iter.next().unwrap())?;
+        let days_of_week = DaysOfWeek::from_field(iter.next().unwrap())?;
+        let years: Years = iter
+            .next()
+            .map(Years::from_field)
+            .unwrap_or_else(|| Ok(Years::all()))?;
+
+        Ok(Schedule::new(
+            seconds,
+            minutes,
+            hours,
+            days_of_month,
+            months,
+            days_of_week,
+            years,
+        ))
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct Field {
+    pub specifiers: Vec<RootSpecifier>, // TODO: expose iterator?
+}
+
+trait FromField
+where
+    Self: Sized,
+{
+    //TODO: Replace with std::convert::TryFrom when stable
+    fn from_field(field: Field) -> Result<Self, Error>;
+}
+
+impl<T> FromField for T
+where
+    T: TimeUnitField,
+{
+    fn from_field(field: Field) -> Result<T, Error> {
+        let mut ordinals = OrdinalSet::new(); // TODO:Combinator
+        for specifier in field.specifiers {
+            let specifier_ordinals: OrdinalSet = T::ordinals_from_root_specifier(&specifier)?;
+            for ordinal in specifier_ordinals {
+                ordinals.insert(T::validate_ordinal(ordinal)?);
+            }
+        }
+        Ok(T::from_ordinal_set(ordinals))
+    }
+}
+
+named!(
+    ordinal<Input, u32>,
+    map_res!(ws!(digit), |x: Input| x.0.parse())
+);
+
+named!(
+    name<Input, String>,
+    map!(ws!(alpha), |x| x.0.to_owned())
+);
+
+named!(
+    point<Input, Specifier>,
+    do_parse!(o: ordinal >> (Specifier::Point(o)))
+);
+
+named!(
+    named_point<Input, RootSpecifier>,
+    do_parse!(n: name >> (RootSpecifier::NamedPoint(n)))
+);
+
+named!(
+    period<Input, RootSpecifier>,
+    complete!(do_parse!(
+        start: specifier >> tag!("/") >> step: ordinal >> (RootSpecifier::Period(start, step))
+    ))
+);
+
+named!(
+    period_with_any<Input, RootSpecifier>,
+    complete!(do_parse!(
+        start: specifier_with_any >> tag!("/") >> step: ordinal >> (RootSpecifier::Period(start, step))
+    ))
+);
+
+named!(
+    range<Input, Specifier>,
+    complete!(do_parse!(
+        start: ordinal >> tag!("-") >> end: ordinal >> (Specifier::Range(start, end))
+    ))
+);
+
+named!(
+    named_range<Input, Specifier>,
+    complete!(do_parse!(
+        start: name >> tag!("-") >> end: name >> (Specifier::NamedRange(start, end))
+    ))
+);
+
+named!(all<Input, Specifier>, do_parse!(tag!("*") >> (Specifier::All)));
+
+named!(any<Input, Specifier>, do_parse!(tag!("?") >> (Specifier::All)));
+
+named!(
+    specifier<Input, Specifier>,
+    alt!(all | range | point | named_range)
+);
+
+named!(
+    specifier_with_any<Input, Specifier>,
+    alt!(
+        any |
+        specifier
+    )
+);
+
+named!(
+    root_specifier<Input, RootSpecifier>,
+    alt!(period | map!(specifier, RootSpecifier::from) | named_point)
+);
+
+named!(
+    root_specifier_with_any<Input, RootSpecifier>,
+    alt!(period_with_any | map!(specifier_with_any, RootSpecifier::from) | named_point)
+);
+
+named!(
+    root_specifier_list<Input, Vec<RootSpecifier>>,
+    ws!(alt!(
+        do_parse!(list: separated_nonempty_list!(tag!(","), root_specifier) >> (list))
+            | do_parse!(spec: root_specifier >> (vec![spec]))
+    ))
+);
+
+named!(
+    root_specifier_list_with_any<Input, Vec<RootSpecifier>>,
+    ws!(alt!(
+        do_parse!(list: separated_nonempty_list!(tag!(","), root_specifier_with_any) >> (list))
+            | do_parse!(spec: root_specifier_with_any >> (vec![spec]))
+    ))
+);
+
+named!(
+    field<Input, Field>,
+    do_parse!(specifiers: root_specifier_list >> (Field { specifiers }))
+);
+
+named!(
+    field_with_any<Input, Field>,
+    alt!(
+        do_parse!(specifiers: root_specifier_list_with_any >> (Field { specifiers }))
+    )
+);
+
+named!(
+    shorthand_yearly<Input, Schedule>,
+    do_parse!(
+        tag!("@yearly")
+            >> (Schedule::new(
+                Seconds::from_ordinal(0),
+                Minutes::from_ordinal(0),
+                Hours::from_ordinal(0),
+                DaysOfMonth::from_ordinal(1),
+                Months::from_ordinal(1),
+                DaysOfWeek::all(),
+                Years::all()
+            ))
+    )
+);
+
+named!(
+    shorthand_monthly<Input, Schedule>,
+    do_parse!(
+        tag!("@monthly")
+            >> (Schedule::new(
+                Seconds::from_ordinal_set(iter::once(0).collect()),
+                Minutes::from_ordinal_set(iter::once(0).collect()),
+                Hours::from_ordinal_set(iter::once(0).collect()),
+                DaysOfMonth::from_ordinal_set(iter::once(1).collect()),
+                Months::all(),
+                DaysOfWeek::all(),
+                Years::all()
+            ))
+    )
+);
+
+named!(
+    shorthand_weekly<Input, Schedule>,
+    do_parse!(
+        tag!("@weekly")
+            >> (Schedule::new(
+                Seconds::from_ordinal_set(iter::once(0).collect()),
+                Minutes::from_ordinal_set(iter::once(0).collect()),
+                Hours::from_ordinal_set(iter::once(0).collect()),
+                DaysOfMonth::all(),
+                Months::all(),
+                DaysOfWeek::from_ordinal_set(iter::once(1).collect()),
+                Years::all()
+            ))
+    )
+);
+
+named!(
+    shorthand_daily<Input, Schedule>,
+    do_parse!(
+        tag!("@daily")
+            >> (Schedule::new(
+                Seconds::from_ordinal_set(iter::once(0).collect()),
+                Minutes::from_ordinal_set(iter::once(0).collect()),
+                Hours::from_ordinal_set(iter::once(0).collect()),
+                DaysOfMonth::all(),
+                Months::all(),
+                DaysOfWeek::all(),
+                Years::all()
+            ))
+    )
+);
+
+named!(
+    shorthand_hourly<Input, Schedule>,
+    do_parse!(
+        tag!("@hourly")
+            >> (Schedule::new(
+                Seconds::from_ordinal_set(iter::once(0).collect()),
+                Minutes::from_ordinal_set(iter::once(0).collect()),
+                Hours::all(),
+                DaysOfMonth::all(),
+                Months::all(),
+                DaysOfWeek::all(),
+                Years::all()
+            ))
+    )
+);
+
+named!(
+    shorthand<Input, Schedule>,
+    alt!(
+        shorthand_yearly
+            | shorthand_monthly
+            | shorthand_weekly
+            | shorthand_daily
+            | shorthand_hourly
+    )
+);
+
+named!(
+    longhand<Input, Schedule>,
+    map_res!(
+        complete!(do_parse!(
+            seconds: field >>
+            minutes: field >>
+            hours: field >>
+            days_of_month: field_with_any >>
+            months: field >>
+            days_of_week: field_with_any >>
+            years: opt!(field) >>
+            eof!() >>
+            ({
+                let mut fields = vec![
+                    seconds,
+                    minutes,
+                    hours,
+                    days_of_month,
+                    months,
+                    days_of_week,
+                ];
+                if let Some(years) = years {
+                    fields.push(years);
+                }
+                fields
+            })
+        )),
+        Schedule::from_field_list
+    )
+);
+
+named!(schedule<Input, Schedule>, alt!(shorthand | longhand));
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_nom_valid_number() {
+        let expression = "1997";
+        point(Input(expression)).unwrap();
+    }
+
+    #[test]
+    fn test_nom_invalid_point() {
+        let expression = "a";
+        assert!(point(Input(expression)).is_err());
+    }
+
+    #[test]
+    fn test_nom_valid_named_point() {
+        let expression = "WED";
+        named_point(Input(expression)).unwrap();
+    }
+
+    #[test]
+    fn test_nom_invalid_named_point() {
+        let expression = "8";
+        assert!(named_point(Input(expression)).is_err());
+    }
+
+    #[test]
+    fn test_nom_valid_period() {
+        let expression = "1/2";
+        period(Input(expression)).unwrap();
+    }
+
+    #[test]
+    fn test_nom_invalid_period() {
+        let expression = "Wed/4";
+        assert!(period(Input(expression)).is_err());
+    }
+
+    #[test]
+    fn test_nom_valid_number_list() {
+        let expression = "1,2";
+        field(Input(expression)).unwrap();
+        field_with_any(Input(expression)).unwrap();
+    }
+
+    #[test]
+    fn test_nom_invalid_number_list() {
+        let expression = ",1,2";
+        assert!(field(Input(expression)).is_err());
+        assert!(field_with_any(Input(expression)).is_err());
+    }
+
+    #[test]
+    fn test_nom_field_with_any_valid_any() {
+        let expression = "?";
+        field_with_any(Input(expression)).unwrap();
+    }
+
+    #[test]
+    fn test_nom_field_invalid_any() {
+        let expression = "?";
+        assert!(field(Input(expression)).is_err());
+    }
+
+    #[test]
+    fn test_nom_valid_range_field() {
+        let expression = "1-4";
+        range(Input(expression)).unwrap();
+    }
+
+    #[test]
+    fn test_nom_valid_period_all() {
+        let expression = "*/2";
+        period(Input(expression)).unwrap();
+    }
+
+    #[test]
+    fn test_nom_valid_period_range() {
+        let expression = "10-20/2";
+        period(Input(expression)).unwrap();
+    }
+
+    #[test]
+    fn test_nom_valid_period_named_range() {
+        let expression = "Mon-Thurs/2";
+        period(Input(expression)).unwrap();
+
+        let expression = "February-November/2";
+        period(Input(expression)).unwrap();
+    }
+
+    #[test]
+    fn test_nom_valid_period_point() {
+        let expression = "10/2";
+        period(Input(expression)).unwrap();
+    }
+
+    #[test]
+    fn test_nom_invalid_period_any() {
+        let expression = "?/2";
+        assert!(period(Input(expression)).is_err());
+    }
+
+    #[test]
+    fn test_nom_invalid_period_named_point() {
+        let expression = "Tues/2";
+        assert!(period(Input(expression)).is_err());
+
+        let expression = "February/2";
+        assert!(period(Input(expression)).is_err());
+    }
+
+    #[test]
+    fn test_nom_invalid_period_specifier_range() {
+        let expression = "10-12/*";
+        assert!(period(Input(expression)).is_err());
+    }
+
+    #[test]
+    fn test_nom_valid_period_with_any_all() {
+        let expression = "*/2";
+        period_with_any(Input(expression)).unwrap();
+    }
+
+    #[test]
+    fn test_nom_valid_period_with_any_range() {
+        let expression = "10-20/2";
+        period_with_any(Input(expression)).unwrap();
+    }
+
+    #[test]
+    fn test_nom_valid_period_with_any_named_range() {
+        let expression = "Mon-Thurs/2";
+        period_with_any(Input(expression)).unwrap();
+
+        let expression = "February-November/2";
+        period_with_any(Input(expression)).unwrap();
+    }
+
+    #[test]
+    fn test_nom_valid_period_with_any_point() {
+        let expression = "10/2";
+        period_with_any(Input(expression)).unwrap();
+    }
+
+    #[test]
+    fn test_nom_valid_period_with_any_any() {
+        let expression = "?/2";
+        period_with_any(Input(expression)).unwrap();
+    }
+
+    #[test]
+    fn test_nom_invalid_period_with_any_named_point() {
+        let expression = "Tues/2";
+        assert!(period_with_any(Input(expression)).is_err());
+
+        let expression = "February/2";
+        assert!(period_with_any(Input(expression)).is_err());
+    }
+
+    #[test]
+    fn test_nom_invalid_period_with_any_specifier_range() {
+        let expression = "10-12/*";
+        assert!(period_with_any(Input(expression)).is_err());
+    }
+
+    #[test]
+    fn test_nom_invalid_range_field() {
+        let expression = "-4";
+        assert!(range(Input(expression)).is_err());
+    }
+
+    #[test]
+    fn test_nom_valid_named_range_field() {
+        let expression = "TUES-THURS";
+        named_range(Input(expression)).unwrap();
+    }
+
+    #[test]
+    fn test_nom_invalid_named_range_field() {
+        let expression = "3-THURS";
+        assert!(named_range(Input(expression)).is_err());
+    }
+
+    #[test]
+    fn test_nom_valid_schedule() {
+        let expression = "* * * * * *";
+        schedule(Input(expression)).unwrap();
+    }
+
+    #[test]
+    fn test_nom_invalid_schedule() {
+        let expression = "* * * *";
+        assert!(schedule(Input(expression)).is_err());
+    }
+
+    #[test]
+    fn test_nom_valid_seconds_list() {
+        let expression = "0,20,40 * * * * *";
+        schedule(Input(expression)).unwrap();
+    }
+
+    #[test]
+    fn test_nom_valid_seconds_range() {
+        let expression = "0-40 * * * * *";
+        schedule(Input(expression)).unwrap();
+    }
+
+    #[test]
+    fn test_nom_valid_seconds_mix() {
+        let expression = "0-5,58 * * * * *";
+        schedule(Input(expression)).unwrap();
+    }
+
+    #[test]
+    fn test_nom_invalid_seconds_range() {
+        let expression = "0-65 * * * * *";
+        assert!(schedule(Input(expression)).is_err());
+    }
+
+    #[test]
+    fn test_nom_invalid_seconds_list() {
+        let expression = "103,12 * * * * *";
+        assert!(schedule(Input(expression)).is_err());
+    }
+
+    #[test]
+    fn test_nom_invalid_seconds_mix() {
+        let expression = "0-5,102 * * * * *";
+        assert!(schedule(Input(expression)).is_err());
+    }
+
+    #[test]
+    fn test_nom_valid_days_of_week_list() {
+        let expression = "* * * * * MON,WED,FRI";
+        schedule(Input(expression)).unwrap();
+    }
+
+    #[test]
+    fn test_nom_invalid_days_of_week_list() {
+        let expression = "* * * * * MON,TURTLE";
+        assert!(schedule(Input(expression)).is_err());
+    }
+
+    #[test]
+    fn test_nom_valid_days_of_week_range() {
+        let expression = "* * * * * MON-FRI";
+        schedule(Input(expression)).unwrap();
+    }
+
+    #[test]
+    fn test_nom_invalid_days_of_week_range() {
+        let expression = "* * * * * BEAR-OWL";
+        assert!(schedule(Input(expression)).is_err());
+    }
+
+    #[test]
+    fn test_nom_invalid_period_with_range_specifier() {
+        let expression = "10-12/10-12 * * * * ?";
+        assert!(schedule(Input(expression)).is_err());
+    }
+
+    #[test]
+    fn test_no_panic_on_nonexistent_time_after() {
+        use chrono::offset::TimeZone;
+        use chrono_tz::Tz;
+
+        let schedule_tz: Tz = "Europe/London".parse().unwrap();
+        let dt = schedule_tz
+            .ymd(2019, 10, 27)
+            .and_hms(0, 3, 29)
+            .checked_add_signed(chrono::Duration::hours(1)) // puts it in the middle of the DST transition
+            .unwrap();
+        let schedule = Schedule::from_str("* * * * * Sat,Sun *").unwrap();
+        let next = schedule.after(&dt).next().unwrap();
+        assert!(next > dt); // test is ensuring line above does not panic
+    }
+
+    #[test]
+    fn test_no_panic_on_nonexistent_time_before() {
+        use chrono::offset::TimeZone;
+        use chrono_tz::Tz;
+
+        let schedule_tz: Tz = "Europe/London".parse().unwrap();
+        let dt = schedule_tz
+            .ymd(2019, 10, 27)
+            .and_hms(0, 3, 29)
+            .checked_add_signed(chrono::Duration::hours(1)) // puts it in the middle of the DST transition
+            .unwrap();
+        let schedule = Schedule::from_str("* * * * * Sat,Sun *").unwrap();
+        let prev = schedule.after(&dt).rev().next().unwrap();
+        assert!(prev < dt); // test is ensuring line above does not panic
+    }
+
+    #[test]
+    fn test_nom_valid_days_of_month_any() {
+        let expression = "* * * ? * *";
+        schedule(Input(expression)).unwrap();
+    }
+
+    #[test]
+    fn test_nom_valid_days_of_week_any() {
+        let expression = "* * * * * ?";
+        schedule(Input(expression)).unwrap();
+    }
+
+    #[test]
+    fn test_nom_valid_days_of_month_any_days_of_week_specific() {
+        let expression = "* * * ? * Mon,Thu";
+        schedule(Input(expression)).unwrap();
+    }
+
+    #[test]
+    fn test_nom_valid_days_of_week_any_days_of_month_specific() {
+        let expression = "* * * 1,2 * ?";
+        schedule(Input(expression)).unwrap();
+    }
+
+    #[test]
+    fn test_nom_valid_dom_and_dow_any() {
+        let expression = "* * * ? * ?";
+        schedule(Input(expression)).unwrap();
+    }
+
+    #[test]
+    fn test_nom_invalid_other_fields_any() {
+        let expression = "? * * * * *";
+        assert!(schedule(Input(expression)).is_err());
+
+        let expression = "* ? * * * *";
+        assert!(schedule(Input(expression)).is_err());
+
+        let expression = "* * ? * * *";
+        assert!(schedule(Input(expression)).is_err());
+
+        let expression = "* * * * ? *";
+        assert!(schedule(Input(expression)).is_err());
+    }
+
+    #[test]
+    fn test_nom_invalid_trailing_characters() {
+        let expression = "* * * * * *foo *";
+        assert!(schedule(Input(expression)).is_err());
+
+        let expression = "* * * * * * * foo";
+        assert!(schedule(Input(expression)).is_err());
+    }
+}

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -578,38 +578,6 @@ mod test {
     }
 
     #[test]
-    fn test_no_panic_on_nonexistent_time_after() {
-        use chrono::offset::TimeZone;
-        use chrono_tz::Tz;
-
-        let schedule_tz: Tz = "Europe/London".parse().unwrap();
-        let dt = schedule_tz
-            .ymd(2019, 10, 27)
-            .and_hms(0, 3, 29)
-            .checked_add_signed(chrono::Duration::hours(1)) // puts it in the middle of the DST transition
-            .unwrap();
-        let schedule = Schedule::from_str("* * * * * Sat,Sun *").unwrap();
-        let next = schedule.after(&dt).next().unwrap();
-        assert!(next > dt); // test is ensuring line above does not panic
-    }
-
-    #[test]
-    fn test_no_panic_on_nonexistent_time_before() {
-        use chrono::offset::TimeZone;
-        use chrono_tz::Tz;
-
-        let schedule_tz: Tz = "Europe/London".parse().unwrap();
-        let dt = schedule_tz
-            .ymd(2019, 10, 27)
-            .and_hms(0, 3, 29)
-            .checked_add_signed(chrono::Duration::hours(1)) // puts it in the middle of the DST transition
-            .unwrap();
-        let schedule = Schedule::from_str("* * * * * Sat,Sun *").unwrap();
-        let prev = schedule.after(&dt).rev().next().unwrap();
-        assert!(prev < dt); // test is ensuring line above does not panic
-    }
-
-    #[test]
     fn test_nom_valid_days_of_month_any() {
         let expression = "* * * ? * *";
         schedule(Input(expression)).unwrap();

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -1,0 +1,201 @@
+use chrono::offset::TimeZone;
+use chrono::{DateTime, Datelike, Duration, Timelike};
+
+use crate::ordinal::Ordinal;
+use crate::time_unit::{DaysOfMonth, Hours, Minutes, Months, Seconds, TimeUnitField};
+
+// TODO: Possibility of one query struct?
+
+pub struct NextAfterQuery<Z>
+where
+    Z: TimeZone,
+{
+    initial_datetime: DateTime<Z>,
+    first_month: bool,
+    first_day_of_month: bool,
+    first_hour: bool,
+    first_minute: bool,
+    first_second: bool,
+}
+
+impl<Z> NextAfterQuery<Z>
+where
+    Z: TimeZone,
+{
+    pub fn from(after: &DateTime<Z>) -> NextAfterQuery<Z> {
+        NextAfterQuery {
+            initial_datetime: after.clone() + Duration::seconds(1),
+            first_month: true,
+            first_day_of_month: true,
+            first_hour: true,
+            first_minute: true,
+            first_second: true,
+        }
+    }
+
+    pub fn year_lower_bound(&self) -> Ordinal {
+        // Unlike the other units, years will never wrap around.
+        self.initial_datetime.year() as u32
+    }
+
+    pub fn month_lower_bound(&mut self) -> Ordinal {
+        if self.first_month {
+            self.first_month = false;
+            return self.initial_datetime.month();
+        }
+        Months::inclusive_min()
+    }
+
+    pub fn reset_month(&mut self) {
+        self.first_month = false;
+        self.reset_day_of_month();
+    }
+
+    pub fn day_of_month_lower_bound(&mut self) -> Ordinal {
+        if self.first_day_of_month {
+            self.first_day_of_month = false;
+            return self.initial_datetime.day();
+        }
+        DaysOfMonth::inclusive_min()
+    }
+
+    pub fn reset_day_of_month(&mut self) {
+        self.first_day_of_month = false;
+        self.reset_hour();
+    }
+
+    pub fn hour_lower_bound(&mut self) -> Ordinal {
+        if self.first_hour {
+            self.first_hour = false;
+            return self.initial_datetime.hour();
+        }
+        Hours::inclusive_min()
+    }
+
+    pub fn reset_hour(&mut self) {
+        self.first_hour = false;
+        self.reset_minute();
+    }
+
+    pub fn minute_lower_bound(&mut self) -> Ordinal {
+        if self.first_minute {
+            self.first_minute = false;
+            return self.initial_datetime.minute();
+        }
+        Minutes::inclusive_min()
+    }
+
+    pub fn reset_minute(&mut self) {
+        self.first_minute = false;
+        self.reset_second();
+    }
+
+    pub fn second_lower_bound(&mut self) -> Ordinal {
+        if self.first_second {
+            self.first_second = false;
+            return self.initial_datetime.second();
+        }
+        Seconds::inclusive_min()
+    }
+
+    pub fn reset_second(&mut self) {
+        self.first_second = false;
+    }
+} // End of impl
+
+pub struct PrevFromQuery<Z>
+where
+    Z: TimeZone,
+{
+    initial_datetime: DateTime<Z>,
+    first_month: bool,
+    first_day_of_month: bool,
+    first_hour: bool,
+    first_minute: bool,
+    first_second: bool,
+}
+
+impl<Z> PrevFromQuery<Z>
+where
+    Z: TimeZone,
+{
+    pub fn from(before: &DateTime<Z>) -> PrevFromQuery<Z> {
+        PrevFromQuery {
+            initial_datetime: before.clone() - Duration::seconds(1),
+            first_month: true,
+            first_day_of_month: true,
+            first_hour: true,
+            first_minute: true,
+            first_second: true,
+        }
+    }
+
+    pub fn year_upper_bound(&self) -> Ordinal {
+        // Unlike the other units, years will never wrap around.
+        self.initial_datetime.year() as u32
+    }
+
+    pub fn month_upper_bound(&mut self) -> Ordinal {
+        if self.first_month {
+            self.first_month = false;
+            return self.initial_datetime.month();
+        }
+        Months::inclusive_max()
+    }
+
+    pub fn reset_month(&mut self) {
+        self.first_month = false;
+        self.reset_day_of_month();
+    }
+
+    pub fn day_of_month_upper_bound(&mut self) -> Ordinal {
+        if self.first_day_of_month {
+            self.first_day_of_month = false;
+            return self.initial_datetime.day();
+        }
+        DaysOfMonth::inclusive_max()
+    }
+
+    pub fn reset_day_of_month(&mut self) {
+        self.first_day_of_month = false;
+        self.reset_hour();
+    }
+
+    pub fn hour_upper_bound(&mut self) -> Ordinal {
+        if self.first_hour {
+            self.first_hour = false;
+            return self.initial_datetime.hour();
+        }
+        Hours::inclusive_max()
+    }
+
+    pub fn reset_hour(&mut self) {
+        self.first_hour = false;
+        self.reset_minute();
+    }
+
+    pub fn minute_upper_bound(&mut self) -> Ordinal {
+        if self.first_minute {
+            self.first_minute = false;
+            return self.initial_datetime.minute();
+        }
+        Minutes::inclusive_max()
+    }
+
+    pub fn reset_minute(&mut self) {
+        self.first_minute = false;
+        self.reset_second();
+    }
+
+    pub fn second_upper_bound(&mut self) -> Ordinal {
+        if self.first_second {
+            self.first_second = false;
+            return self.initial_datetime.second();
+        }
+        Seconds::inclusive_max()
+    }
+
+    pub fn reset_second(&mut self) {
+        self.first_second = false;
+    }
+}

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -2,13 +2,13 @@ use crate::error::{Error, ErrorKind};
 use chrono::offset::TimeZone;
 use chrono::{DateTime, Datelike, Duration, Timelike, Utc};
 use nom::{types::CompleteStr as Input, *};
-use std::collections::BTreeSet;
 use std::collections::Bound::{Included, Unbounded};
 use std::fmt::{Display, Formatter, Result as FmtResult};
 use std::iter::{self, Iterator};
 use std::str::{self, FromStr};
 
 use crate::time_unit::*;
+use crate::ordinal::*;
 
 #[derive(Clone, Debug)]
 pub struct Schedule {
@@ -599,13 +599,6 @@ where
         }
     }
 }
-
-pub type Ordinal = u32;
-// TODO: Make OrdinalSet an enum.
-// It should either be a BTreeSet of ordinals or an `All` option to save space.
-// `All` can iterate from inclusive_min to inclusive_max and answer membership
-// queries
-pub type OrdinalSet = BTreeSet<Ordinal>;
 
 #[derive(Debug, PartialEq)]
 pub enum Specifier {

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -9,6 +9,7 @@ use std::str::{self, FromStr};
 
 use crate::time_unit::*;
 use crate::ordinal::*;
+use crate::specifier::*;
 
 #[derive(Clone, Debug)]
 pub struct Schedule {
@@ -597,34 +598,6 @@ where
             self.is_done = true;
             None
         }
-    }
-}
-
-#[derive(Debug, PartialEq)]
-pub enum Specifier {
-    All,
-    Point(Ordinal),
-    Range(Ordinal, Ordinal),
-    NamedRange(String, String),
-}
-
-// Separating out a root specifier allows for a higher tiered specifier, allowing us to achieve
-// periods with base values that are more advanced than an ordinal:
-// - all: '*/2'
-// - range: '10-2/2'
-// - named range: 'Mon-Thurs/2'
-//
-// Without this separation we would end up with invalid combinations such as 'Mon/2'
-#[derive(Debug, PartialEq)]
-pub enum RootSpecifier {
-    Specifier(Specifier),
-    Period(Specifier, u32),
-    NamedPoint(String),
-}
-
-impl From<Specifier> for RootSpecifier {
-    fn from(specifier: Specifier) -> Self {
-        Self::Specifier(specifier)
     }
 }
 

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -1,20 +1,22 @@
-use crate::error::{Error, ErrorKind};
+
 use chrono::offset::TimeZone;
 use chrono::{DateTime, Datelike, Utc};
-use nom::{types::CompleteStr as Input, *};
 use std::collections::Bound::{Included, Unbounded};
 use std::fmt::{Display, Formatter, Result as FmtResult};
-use std::iter::{self, Iterator};
-use std::str::{self, FromStr};
 
 use crate::time_unit::*;
 use crate::ordinal::*;
-use crate::specifier::*;
 use crate::queries::*;
+
+impl From<Schedule> for String {
+    fn from(schedule: Schedule) -> String {
+        schedule.source.unwrap()
+    }
+}
 
 #[derive(Clone, Debug)]
 pub struct Schedule {
-    source: Option<String>,
+    pub source: Option<String>, //TODO: remove pub
     years: Years,
     days_of_week: DaysOfWeek,
     months: Months,
@@ -25,42 +27,7 @@ pub struct Schedule {
 }
 
 impl Schedule {
-    fn from_field_list(fields: Vec<Field>) -> Result<Schedule, Error> {
-        let number_of_fields = fields.len();
-        if number_of_fields != 6 && number_of_fields != 7 {
-            return Err(ErrorKind::Expression(format!(
-                "Expression has {} fields. Valid cron \
-                 expressions have 6 or 7.",
-                number_of_fields
-            ))
-            .into());
-        }
-
-        let mut iter = fields.into_iter();
-
-        let seconds = Seconds::from_field(iter.next().unwrap())?;
-        let minutes = Minutes::from_field(iter.next().unwrap())?;
-        let hours = Hours::from_field(iter.next().unwrap())?;
-        let days_of_month = DaysOfMonth::from_field(iter.next().unwrap())?;
-        let months = Months::from_field(iter.next().unwrap())?;
-        let days_of_week = DaysOfWeek::from_field(iter.next().unwrap())?;
-        let years: Years = iter
-            .next()
-            .map(Years::from_field)
-            .unwrap_or_else(|| Ok(Years::all()))?;
-
-        Ok(Schedule::from(
-            seconds,
-            minutes,
-            hours,
-            days_of_month,
-            months,
-            days_of_week,
-            years,
-        ))
-    }
-
-    fn from(
+    pub fn new(
         seconds: Seconds,
         minutes: Minutes,
         hours: Hours,
@@ -321,25 +288,6 @@ impl Schedule {
     }
 }
 
-impl FromStr for Schedule {
-    type Err = Error;
-    fn from_str(expression: &str) -> Result<Self, Self::Err> {
-        match schedule(Input(expression)) {
-            Ok((_, mut schedule)) => {
-                schedule.source.replace(expression.to_owned());
-                Ok(schedule)
-            } // Extract from nom tuple
-            Err(_) => Err(ErrorKind::Expression("Invalid cron expression.".to_owned()).into()), //TODO: Details
-        }
-    }
-}
-
-impl From<Schedule> for String {
-    fn from(schedule: Schedule) -> String {
-        schedule.source.unwrap()
-    }
-}
-
 impl Display for Schedule {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
         self.source.as_ref().map(|s| write!(f, "{}", s)).unwrap()
@@ -408,262 +356,6 @@ where
     }
 }
 
-#[derive(Debug, PartialEq)]
-pub struct Field {
-    pub specifiers: Vec<RootSpecifier>, // TODO: expose iterator?
-}
-
-trait FromField
-where
-    Self: Sized,
-{
-    //TODO: Replace with std::convert::TryFrom when stable
-    fn from_field(field: Field) -> Result<Self, Error>;
-}
-
-impl<T> FromField for T
-where
-    T: TimeUnitField,
-{
-    fn from_field(field: Field) -> Result<T, Error> {
-        let mut ordinals = OrdinalSet::new(); // TODO:Combinator
-        for specifier in field.specifiers {
-            let specifier_ordinals: OrdinalSet = T::ordinals_from_root_specifier(&specifier)?;
-            for ordinal in specifier_ordinals {
-                ordinals.insert(T::validate_ordinal(ordinal)?);
-            }
-        }
-        Ok(T::from_ordinal_set(ordinals))
-    }
-}
-
-named!(
-    ordinal<Input, u32>,
-    map_res!(ws!(digit), |x: Input| x.0.parse())
-);
-
-named!(
-    name<Input, String>,
-    map!(ws!(alpha), |x| x.0.to_owned())
-);
-
-named!(
-    point<Input, Specifier>,
-    do_parse!(o: ordinal >> (Specifier::Point(o)))
-);
-
-named!(
-    named_point<Input, RootSpecifier>,
-    do_parse!(n: name >> (RootSpecifier::NamedPoint(n)))
-);
-
-named!(
-    period<Input, RootSpecifier>,
-    complete!(do_parse!(
-        start: specifier >> tag!("/") >> step: ordinal >> (RootSpecifier::Period(start, step))
-    ))
-);
-
-named!(
-    period_with_any<Input, RootSpecifier>,
-    complete!(do_parse!(
-        start: specifier_with_any >> tag!("/") >> step: ordinal >> (RootSpecifier::Period(start, step))
-    ))
-);
-
-named!(
-    range<Input, Specifier>,
-    complete!(do_parse!(
-        start: ordinal >> tag!("-") >> end: ordinal >> (Specifier::Range(start, end))
-    ))
-);
-
-named!(
-    named_range<Input, Specifier>,
-    complete!(do_parse!(
-        start: name >> tag!("-") >> end: name >> (Specifier::NamedRange(start, end))
-    ))
-);
-
-named!(all<Input, Specifier>, do_parse!(tag!("*") >> (Specifier::All)));
-
-named!(any<Input, Specifier>, do_parse!(tag!("?") >> (Specifier::All)));
-
-named!(
-    specifier<Input, Specifier>,
-    alt!(all | range | point | named_range)
-);
-
-named!(
-    specifier_with_any<Input, Specifier>,
-    alt!(
-        any |
-        specifier
-    )
-);
-
-named!(
-    root_specifier<Input, RootSpecifier>,
-    alt!(period | map!(specifier, RootSpecifier::from) | named_point)
-);
-
-named!(
-    root_specifier_with_any<Input, RootSpecifier>,
-    alt!(period_with_any | map!(specifier_with_any, RootSpecifier::from) | named_point)
-);
-
-named!(
-    root_specifier_list<Input, Vec<RootSpecifier>>,
-    ws!(alt!(
-        do_parse!(list: separated_nonempty_list!(tag!(","), root_specifier) >> (list))
-            | do_parse!(spec: root_specifier >> (vec![spec]))
-    ))
-);
-
-named!(
-    root_specifier_list_with_any<Input, Vec<RootSpecifier>>,
-    ws!(alt!(
-        do_parse!(list: separated_nonempty_list!(tag!(","), root_specifier_with_any) >> (list))
-            | do_parse!(spec: root_specifier_with_any >> (vec![spec]))
-    ))
-);
-
-named!(
-    field<Input, Field>,
-    do_parse!(specifiers: root_specifier_list >> (Field { specifiers }))
-);
-
-named!(
-    field_with_any<Input, Field>,
-    alt!(
-        do_parse!(specifiers: root_specifier_list_with_any >> (Field { specifiers }))
-    )
-);
-
-named!(
-    shorthand_yearly<Input, Schedule>,
-    do_parse!(
-        tag!("@yearly")
-            >> (Schedule::from(
-                Seconds::from_ordinal(0),
-                Minutes::from_ordinal(0),
-                Hours::from_ordinal(0),
-                DaysOfMonth::from_ordinal(1),
-                Months::from_ordinal(1),
-                DaysOfWeek::all(),
-                Years::all()
-            ))
-    )
-);
-
-named!(
-    shorthand_monthly<Input, Schedule>,
-    do_parse!(
-        tag!("@monthly")
-            >> (Schedule::from(
-                Seconds::from_ordinal_set(iter::once(0).collect()),
-                Minutes::from_ordinal_set(iter::once(0).collect()),
-                Hours::from_ordinal_set(iter::once(0).collect()),
-                DaysOfMonth::from_ordinal_set(iter::once(1).collect()),
-                Months::all(),
-                DaysOfWeek::all(),
-                Years::all()
-            ))
-    )
-);
-
-named!(
-    shorthand_weekly<Input, Schedule>,
-    do_parse!(
-        tag!("@weekly")
-            >> (Schedule::from(
-                Seconds::from_ordinal_set(iter::once(0).collect()),
-                Minutes::from_ordinal_set(iter::once(0).collect()),
-                Hours::from_ordinal_set(iter::once(0).collect()),
-                DaysOfMonth::all(),
-                Months::all(),
-                DaysOfWeek::from_ordinal_set(iter::once(1).collect()),
-                Years::all()
-            ))
-    )
-);
-
-named!(
-    shorthand_daily<Input, Schedule>,
-    do_parse!(
-        tag!("@daily")
-            >> (Schedule::from(
-                Seconds::from_ordinal_set(iter::once(0).collect()),
-                Minutes::from_ordinal_set(iter::once(0).collect()),
-                Hours::from_ordinal_set(iter::once(0).collect()),
-                DaysOfMonth::all(),
-                Months::all(),
-                DaysOfWeek::all(),
-                Years::all()
-            ))
-    )
-);
-
-named!(
-    shorthand_hourly<Input, Schedule>,
-    do_parse!(
-        tag!("@hourly")
-            >> (Schedule::from(
-                Seconds::from_ordinal_set(iter::once(0).collect()),
-                Minutes::from_ordinal_set(iter::once(0).collect()),
-                Hours::all(),
-                DaysOfMonth::all(),
-                Months::all(),
-                DaysOfWeek::all(),
-                Years::all()
-            ))
-    )
-);
-
-named!(
-    shorthand<Input, Schedule>,
-    alt!(
-        shorthand_yearly
-            | shorthand_monthly
-            | shorthand_weekly
-            | shorthand_daily
-            | shorthand_hourly
-    )
-);
-
-named!(
-    longhand<Input, Schedule>,
-    map_res!(
-        complete!(do_parse!(
-            seconds: field >>
-            minutes: field >>
-            hours: field >>
-            days_of_month: field_with_any >>
-            months: field >>
-            days_of_week: field_with_any >>
-            years: opt!(field) >>
-            eof!() >>
-            ({
-                let mut fields = vec![
-                    seconds,
-                    minutes,
-                    hours,
-                    days_of_month,
-                    months,
-                    days_of_week,
-                ];
-                if let Some(years) = years {
-                    fields.push(years);
-                }
-                fields
-            })
-        )),
-        Schedule::from_field_list
-    )
-);
-
-named!(schedule<Input, Schedule>, alt!(shorthand | longhand));
-
 fn is_leap_year(year: Ordinal) -> bool {
     let by_four = year % 4 == 0;
     let by_hundred = year % 100 == 0;
@@ -681,464 +373,124 @@ fn days_in_month(month: Ordinal, year: Ordinal) -> u32 {
     }
 }
 
-#[test]
-fn test_next_and_prev_from() {
-    let expression = "0 5,13,40-42 17 1 Jan *";
-    let schedule = schedule(Input(expression)).unwrap().1;
-
-    let next = schedule.next_after(&Utc::now());
-    println!("NEXT AFTER for {} {:?}", expression, next);
-    assert!(next.is_some());
-
-    let next2 = schedule.next_after(&next.unwrap());
-    println!("NEXT2 AFTER for {} {:?}", expression, next2);
-    assert!(next2.is_some());
-
-    let prev = schedule.prev_from(&next2.unwrap());
-    println!("PREV FROM for {} {:?}", expression, prev);
-    assert!(prev.is_some());
-    assert_eq!(prev, next);
-}
-
-#[test]
-fn test_prev_from() {
-    let expression = "0 5,13,40-42 17 1 Jan *";
-    let schedule = schedule(Input(expression)).unwrap().1;
-    let prev = schedule.prev_from(&Utc::now());
-    println!("PREV FROM for {} {:?}", expression, prev);
-    assert!(prev.is_some());
-}
-
-#[test]
-fn test_next_after() {
-    let expression = "0 5,13,40-42 17 1 Jan *";
-    let schedule = schedule(Input(expression)).unwrap().1;
-    let next = schedule.next_after(&Utc::now());
-    println!("NEXT AFTER for {} {:?}", expression, next);
-    assert!(next.is_some());
-}
-
-#[test]
-fn test_upcoming_utc() {
-    let expression = "0 0,30 0,6,12,18 1,15 Jan-March Thurs";
-    let schedule = schedule(Input(expression)).unwrap().1;
-    let mut upcoming = schedule.upcoming(Utc);
-    let next1 = upcoming.next();
-    assert!(next1.is_some());
-    let next2 = upcoming.next();
-    assert!(next2.is_some());
-    let next3 = upcoming.next();
-    assert!(next3.is_some());
-    println!("Upcoming 1 for {} {:?}", expression, next1);
-    println!("Upcoming 2 for {} {:?}", expression, next2);
-    println!("Upcoming 3 for {} {:?}", expression, next3);
-}
-
-#[test]
-fn test_upcoming_rev_utc() {
-    let expression = "0 0,30 0,6,12,18 1,15 Jan-March Thurs";
-    let schedule = schedule(Input(expression)).unwrap().1;
-    let mut upcoming = schedule.upcoming(Utc).rev();
-    let prev1 = upcoming.next();
-    assert!(prev1.is_some());
-    let prev2 = upcoming.next();
-    assert!(prev2.is_some());
-    let prev3 = upcoming.next();
-    assert!(prev3.is_some());
-    println!("Prev Upcoming 1 for {} {:?}", expression, prev1);
-    println!("Prev Upcoming 2 for {} {:?}", expression, prev2);
-    println!("Prev Upcoming 3 for {} {:?}", expression, prev3);
-}
-
-#[test]
-fn test_upcoming_local() {
-    use chrono::Local;
-    let expression = "0 0,30 0,6,12,18 1,15 Jan-March Thurs";
-    let schedule = schedule(Input(expression)).unwrap().1;
-    let mut upcoming = schedule.upcoming(Local);
-    let next1 = upcoming.next();
-    assert!(next1.is_some());
-    let next2 = upcoming.next();
-    assert!(next2.is_some());
-    let next3 = upcoming.next();
-    assert!(next3.is_some());
-    println!("Upcoming 1 for {} {:?}", expression, next1);
-    println!("Upcoming 2 for {} {:?}", expression, next2);
-    println!("Upcoming 3 for {} {:?}", expression, next3);
-}
-
-#[test]
-fn test_schedule_to_string() {
-    let expression = "* 1,2,3 * * * *";
-    let schedule: Schedule = Schedule::from_str(expression).unwrap();
-    let result = String::from(schedule);
-    assert_eq!(expression, result);
-}
-
-#[test]
-fn test_display_schedule() {
-    use std::fmt::Write;
-    let expression = "@monthly";
-    let schedule = Schedule::from_str(expression).unwrap();
-    let mut result = String::new();
-    write!(result, "{}", schedule).unwrap();
-    assert_eq!(expression, result);
-}
-
-#[test]
-fn test_valid_from_str() {
-    let schedule = Schedule::from_str("0 0,30 0,6,12,18 1,15 Jan-March Thurs");
-    schedule.unwrap();
-}
-
-#[test]
-fn test_invalid_from_str() {
-    let schedule = Schedule::from_str("cheesecake 0,30 0,6,12,18 1,15 Jan-March Thurs");
-    assert!(schedule.is_err());
-}
-
-#[test]
-fn test_nom_valid_number() {
-    let expression = "1997";
-    point(Input(expression)).unwrap();
-}
-
-#[test]
-fn test_nom_invalid_point() {
-    let expression = "a";
-    assert!(point(Input(expression)).is_err());
-}
-
-#[test]
-fn test_nom_valid_named_point() {
-    let expression = "WED";
-    named_point(Input(expression)).unwrap();
-}
-
-#[test]
-fn test_nom_invalid_named_point() {
-    let expression = "8";
-    assert!(named_point(Input(expression)).is_err());
-}
-
-#[test]
-fn test_nom_valid_period() {
-    let expression = "1/2";
-    period(Input(expression)).unwrap();
-}
-
-#[test]
-fn test_nom_invalid_period() {
-    let expression = "Wed/4";
-    assert!(period(Input(expression)).is_err());
-}
-
-#[test]
-fn test_nom_valid_number_list() {
-    let expression = "1,2";
-    field(Input(expression)).unwrap();
-    field_with_any(Input(expression)).unwrap();
-}
-
-#[test]
-fn test_nom_invalid_number_list() {
-    let expression = ",1,2";
-    assert!(field(Input(expression)).is_err());
-    assert!(field_with_any(Input(expression)).is_err());
-}
-
-#[test]
-fn test_nom_field_with_any_valid_any() {
-    let expression = "?";
-    field_with_any(Input(expression)).unwrap();
-}
-
-#[test]
-fn test_nom_field_invalid_any() {
-    let expression = "?";
-    assert!(field(Input(expression)).is_err());
-}
-
-#[test]
-fn test_nom_valid_range_field() {
-    let expression = "1-4";
-    range(Input(expression)).unwrap();
-}
-
-#[test]
-fn test_nom_valid_period_all() {
-    let expression = "*/2";
-    period(Input(expression)).unwrap();
-}
-
-#[test]
-fn test_nom_valid_period_range() {
-    let expression = "10-20/2";
-    period(Input(expression)).unwrap();
-}
-
-#[test]
-fn test_nom_valid_period_named_range() {
-    let expression = "Mon-Thurs/2";
-    period(Input(expression)).unwrap();
-
-    let expression = "February-November/2";
-    period(Input(expression)).unwrap();
-}
-
-#[test]
-fn test_nom_valid_period_point() {
-    let expression = "10/2";
-    period(Input(expression)).unwrap();
-}
-
-#[test]
-fn test_nom_invalid_period_any() {
-    let expression = "?/2";
-    assert!(period(Input(expression)).is_err());
-}
-
-#[test]
-fn test_nom_invalid_period_named_point() {
-    let expression = "Tues/2";
-    assert!(period(Input(expression)).is_err());
-
-    let expression = "February/2";
-    assert!(period(Input(expression)).is_err());
-}
-
-#[test]
-fn test_nom_invalid_period_specifier_range() {
-    let expression = "10-12/*";
-    assert!(period(Input(expression)).is_err());
-}
-
-#[test]
-fn test_nom_valid_period_with_any_all() {
-    let expression = "*/2";
-    period_with_any(Input(expression)).unwrap();
-}
-
-#[test]
-fn test_nom_valid_period_with_any_range() {
-    let expression = "10-20/2";
-    period_with_any(Input(expression)).unwrap();
-}
-
-#[test]
-fn test_nom_valid_period_with_any_named_range() {
-    let expression = "Mon-Thurs/2";
-    period_with_any(Input(expression)).unwrap();
-
-    let expression = "February-November/2";
-    period_with_any(Input(expression)).unwrap();
-}
-
-#[test]
-fn test_nom_valid_period_with_any_point() {
-    let expression = "10/2";
-    period_with_any(Input(expression)).unwrap();
-}
-
-#[test]
-fn test_nom_valid_period_with_any_any() {
-    let expression = "?/2";
-    period_with_any(Input(expression)).unwrap();
-}
-
-#[test]
-fn test_nom_invalid_period_with_any_named_point() {
-    let expression = "Tues/2";
-    assert!(period_with_any(Input(expression)).is_err());
-
-    let expression = "February/2";
-    assert!(period_with_any(Input(expression)).is_err());
-}
-
-#[test]
-fn test_nom_invalid_period_with_any_specifier_range() {
-    let expression = "10-12/*";
-    assert!(period_with_any(Input(expression)).is_err());
-}
-
-#[test]
-fn test_nom_invalid_range_field() {
-    let expression = "-4";
-    assert!(range(Input(expression)).is_err());
-}
-
-#[test]
-fn test_nom_valid_named_range_field() {
-    let expression = "TUES-THURS";
-    named_range(Input(expression)).unwrap();
-}
-
-#[test]
-fn test_nom_invalid_named_range_field() {
-    let expression = "3-THURS";
-    assert!(named_range(Input(expression)).is_err());
-}
-
-#[test]
-fn test_nom_valid_schedule() {
-    let expression = "* * * * * *";
-    schedule(Input(expression)).unwrap();
-}
-
-#[test]
-fn test_nom_invalid_schedule() {
-    let expression = "* * * *";
-    assert!(schedule(Input(expression)).is_err());
-}
-
-#[test]
-fn test_nom_valid_seconds_list() {
-    let expression = "0,20,40 * * * * *";
-    schedule(Input(expression)).unwrap();
-}
-
-#[test]
-fn test_nom_valid_seconds_range() {
-    let expression = "0-40 * * * * *";
-    schedule(Input(expression)).unwrap();
-}
-
-#[test]
-fn test_nom_valid_seconds_mix() {
-    let expression = "0-5,58 * * * * *";
-    schedule(Input(expression)).unwrap();
-}
-
-#[test]
-fn test_nom_invalid_seconds_range() {
-    let expression = "0-65 * * * * *";
-    assert!(schedule(Input(expression)).is_err());
-}
-
-#[test]
-fn test_nom_invalid_seconds_list() {
-    let expression = "103,12 * * * * *";
-    assert!(schedule(Input(expression)).is_err());
-}
-
-#[test]
-fn test_nom_invalid_seconds_mix() {
-    let expression = "0-5,102 * * * * *";
-    assert!(schedule(Input(expression)).is_err());
-}
-
-#[test]
-fn test_nom_valid_days_of_week_list() {
-    let expression = "* * * * * MON,WED,FRI";
-    schedule(Input(expression)).unwrap();
-}
-
-#[test]
-fn test_nom_invalid_days_of_week_list() {
-    let expression = "* * * * * MON,TURTLE";
-    assert!(schedule(Input(expression)).is_err());
-}
-
-#[test]
-fn test_nom_valid_days_of_week_range() {
-    let expression = "* * * * * MON-FRI";
-    schedule(Input(expression)).unwrap();
-}
-
-#[test]
-fn test_nom_invalid_days_of_week_range() {
-    let expression = "* * * * * BEAR-OWL";
-    assert!(schedule(Input(expression)).is_err());
-}
-
-#[test]
-fn test_nom_invalid_period_with_range_specifier() {
-    let expression = "10-12/10-12 * * * * ?";
-    assert!(schedule(Input(expression)).is_err());
-}
-
-#[test]
-fn test_no_panic_on_nonexistent_time_after() {
-    use chrono::offset::TimeZone;
-    use chrono_tz::Tz;
-
-    let schedule_tz: Tz = "Europe/London".parse().unwrap();
-    let dt = schedule_tz
-        .ymd(2019, 10, 27)
-        .and_hms(0, 3, 29)
-        .checked_add_signed(chrono::Duration::hours(1)) // puts it in the middle of the DST transition
-        .unwrap();
-    let schedule = Schedule::from_str("* * * * * Sat,Sun *").unwrap();
-    let next = schedule.after(&dt).next().unwrap();
-    assert!(next > dt); // test is ensuring line above does not panic
-}
-
-#[test]
-fn test_no_panic_on_nonexistent_time_before() {
-    use chrono::offset::TimeZone;
-    use chrono_tz::Tz;
-
-    let schedule_tz: Tz = "Europe/London".parse().unwrap();
-    let dt = schedule_tz
-        .ymd(2019, 10, 27)
-        .and_hms(0, 3, 29)
-        .checked_add_signed(chrono::Duration::hours(1)) // puts it in the middle of the DST transition
-        .unwrap();
-    let schedule = Schedule::from_str("* * * * * Sat,Sun *").unwrap();
-    let prev = schedule.after(&dt).rev().next().unwrap();
-    assert!(prev < dt); // test is ensuring line above does not panic
-}
-
-#[test]
-fn test_nom_valid_days_of_month_any() {
-    let expression = "* * * ? * *";
-    schedule(Input(expression)).unwrap();
-}
-
-#[test]
-fn test_nom_valid_days_of_week_any() {
-    let expression = "* * * * * ?";
-    schedule(Input(expression)).unwrap();
-}
-
-#[test]
-fn test_nom_valid_days_of_month_any_days_of_week_specific() {
-    let expression = "* * * ? * Mon,Thu";
-    schedule(Input(expression)).unwrap();
-}
-
-#[test]
-fn test_nom_valid_days_of_week_any_days_of_month_specific() {
-    let expression = "* * * 1,2 * ?";
-    schedule(Input(expression)).unwrap();
-}
-
-#[test]
-fn test_nom_valid_dom_and_dow_any() {
-    let expression = "* * * ? * ?";
-    schedule(Input(expression)).unwrap();
-}
-
-#[test]
-fn test_nom_invalid_other_fields_any() {
-    let expression = "? * * * * *";
-    assert!(schedule(Input(expression)).is_err());
-
-    let expression = "* ? * * * *";
-    assert!(schedule(Input(expression)).is_err());
-
-    let expression = "* * ? * * *";
-    assert!(schedule(Input(expression)).is_err());
-
-    let expression = "* * * * ? *";
-    assert!(schedule(Input(expression)).is_err());
-}
-
-#[test]
-fn test_nom_invalid_trailing_characters() {
-    let expression = "* * * * * *foo *";
-    assert!(schedule(Input(expression)).is_err());
-
-    let expression = "* * * * * * * foo";
-    assert!(schedule(Input(expression)).is_err());
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::str::{FromStr};
+
+    #[test]
+    fn test_next_and_prev_from() {
+        let expression = "0 5,13,40-42 17 1 Jan *";
+        let schedule = Schedule::from_str(expression).unwrap();
+
+        let next = schedule.next_after(&Utc::now());
+        println!("NEXT AFTER for {} {:?}", expression, next);
+        assert!(next.is_some());
+
+        let next2 = schedule.next_after(&next.unwrap());
+        println!("NEXT2 AFTER for {} {:?}", expression, next2);
+        assert!(next2.is_some());
+
+        let prev = schedule.prev_from(&next2.unwrap());
+        println!("PREV FROM for {} {:?}", expression, prev);
+        assert!(prev.is_some());
+        assert_eq!(prev, next);
+    }
+
+    #[test]
+    fn test_prev_from() {
+        let expression = "0 5,13,40-42 17 1 Jan *";
+        let schedule = Schedule::from_str(expression).unwrap();
+        let prev = schedule.prev_from(&Utc::now());
+        println!("PREV FROM for {} {:?}", expression, prev);
+        assert!(prev.is_some());
+    }
+
+    #[test]
+    fn test_next_after() {
+        let expression = "0 5,13,40-42 17 1 Jan *";
+        let schedule = Schedule::from_str(expression).unwrap();
+        let next = schedule.next_after(&Utc::now());
+        println!("NEXT AFTER for {} {:?}", expression, next);
+        assert!(next.is_some());
+    }
+
+    #[test]
+    fn test_upcoming_utc() {
+        let expression = "0 0,30 0,6,12,18 1,15 Jan-March Thurs";
+        let schedule = Schedule::from_str(expression).unwrap();
+        let mut upcoming = schedule.upcoming(Utc);
+        let next1 = upcoming.next();
+        assert!(next1.is_some());
+        let next2 = upcoming.next();
+        assert!(next2.is_some());
+        let next3 = upcoming.next();
+        assert!(next3.is_some());
+        println!("Upcoming 1 for {} {:?}", expression, next1);
+        println!("Upcoming 2 for {} {:?}", expression, next2);
+        println!("Upcoming 3 for {} {:?}", expression, next3);
+    }
+
+    #[test]
+    fn test_upcoming_rev_utc() {
+        let expression = "0 0,30 0,6,12,18 1,15 Jan-March Thurs";
+        let schedule = Schedule::from_str(expression).unwrap();
+        let mut upcoming = schedule.upcoming(Utc).rev();
+        let prev1 = upcoming.next();
+        assert!(prev1.is_some());
+        let prev2 = upcoming.next();
+        assert!(prev2.is_some());
+        let prev3 = upcoming.next();
+        assert!(prev3.is_some());
+        println!("Prev Upcoming 1 for {} {:?}", expression, prev1);
+        println!("Prev Upcoming 2 for {} {:?}", expression, prev2);
+        println!("Prev Upcoming 3 for {} {:?}", expression, prev3);
+    }
+
+    #[test]
+    fn test_upcoming_local() {
+        use chrono::Local;
+        let expression = "0 0,30 0,6,12,18 1,15 Jan-March Thurs";
+        let schedule = Schedule::from_str(expression).unwrap();
+        let mut upcoming = schedule.upcoming(Local);
+        let next1 = upcoming.next();
+        assert!(next1.is_some());
+        let next2 = upcoming.next();
+        assert!(next2.is_some());
+        let next3 = upcoming.next();
+        assert!(next3.is_some());
+        println!("Upcoming 1 for {} {:?}", expression, next1);
+        println!("Upcoming 2 for {} {:?}", expression, next2);
+        println!("Upcoming 3 for {} {:?}", expression, next3);
+    }
+
+    #[test]
+    fn test_schedule_to_string() {
+        let expression = "* 1,2,3 * * * *";
+        let schedule: Schedule = Schedule::from_str(expression).unwrap();
+        let result = String::from(schedule);
+        assert_eq!(expression, result);
+    }
+
+    #[test]
+    fn test_display_schedule() {
+        use std::fmt::Write;
+        let expression = "@monthly";
+        let schedule = Schedule::from_str(expression).unwrap();
+        let mut result = String::new();
+        write!(result, "{}", schedule).unwrap();
+        assert_eq!(expression, result);
+    }
+
+    #[test]
+    fn test_valid_from_str() {
+        let schedule = Schedule::from_str("0 0,30 0,6,12,18 1,15 Jan-March Thurs");
+        schedule.unwrap();
+    }
+
+    #[test]
+    fn test_invalid_from_str() {
+        let schedule = Schedule::from_str("cheesecake 0,30 0,6,12,18 1,15 Jan-March Thurs");
+        assert!(schedule.is_err());
+    }
 }

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -493,4 +493,36 @@ mod test {
         let schedule = Schedule::from_str("cheesecake 0,30 0,6,12,18 1,15 Jan-March Thurs");
         assert!(schedule.is_err());
     }
+
+    #[test]
+    fn test_no_panic_on_nonexistent_time_after() {
+        use chrono::offset::TimeZone;
+        use chrono_tz::Tz;
+
+        let schedule_tz: Tz = "Europe/London".parse().unwrap();
+        let dt = schedule_tz
+            .ymd(2019, 10, 27)
+            .and_hms(0, 3, 29)
+            .checked_add_signed(chrono::Duration::hours(1)) // puts it in the middle of the DST transition
+            .unwrap();
+        let schedule = Schedule::from_str("* * * * * Sat,Sun *").unwrap();
+        let next = schedule.after(&dt).next().unwrap();
+        assert!(next > dt); // test is ensuring line above does not panic
+    }
+
+    #[test]
+    fn test_no_panic_on_nonexistent_time_before() {
+        use chrono::offset::TimeZone;
+        use chrono_tz::Tz;
+
+        let schedule_tz: Tz = "Europe/London".parse().unwrap();
+        let dt = schedule_tz
+            .ymd(2019, 10, 27)
+            .and_hms(0, 3, 29)
+            .checked_add_signed(chrono::Duration::hours(1)) // puts it in the middle of the DST transition
+            .unwrap();
+        let schedule = Schedule::from_str("* * * * * Sat,Sun *").unwrap();
+        let prev = schedule.after(&dt).rev().next().unwrap();
+        assert!(prev < dt); // test is ensuring line above does not panic
+    }
 }

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -27,7 +27,7 @@ pub struct Schedule {
 }
 
 impl Schedule {
-    pub fn new(
+    pub(crate) fn new(
         seconds: Seconds,
         minutes: Minutes,
         hours: Hours,

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -16,7 +16,7 @@ impl From<Schedule> for String {
 
 #[derive(Clone, Debug)]
 pub struct Schedule {
-    pub source: Option<String>, //TODO: remove pub
+    pub(crate) source: Option<String>, //TODO: remove pub
     years: Years,
     days_of_week: DaysOfWeek,
     months: Months,

--- a/src/specifier.rs
+++ b/src/specifier.rs
@@ -1,0 +1,29 @@
+use crate::ordinal::*;
+
+#[derive(Debug, PartialEq)]
+pub enum Specifier {
+    All,
+    Point(Ordinal),
+    Range(Ordinal, Ordinal),
+    NamedRange(String, String),
+}
+
+// Separating out a root specifier allows for a higher tiered specifier, allowing us to achieve
+// periods with base values that are more advanced than an ordinal:
+// - all: '*/2'
+// - range: '10-2/2'
+// - named range: 'Mon-Thurs/2'
+//
+// Without this separation we would end up with invalid combinations such as 'Mon/2'
+#[derive(Debug, PartialEq)]
+pub enum RootSpecifier {
+    Specifier(Specifier),
+    Period(Specifier, u32),
+    NamedPoint(String),
+}
+
+impl From<Specifier> for RootSpecifier {
+    fn from(specifier: Specifier) -> Self {
+        Self::Specifier(specifier)
+    }
+}

--- a/src/time_unit/days_of_month.rs
+++ b/src/time_unit/days_of_month.rs
@@ -1,4 +1,4 @@
-use crate::schedule::{Ordinal, OrdinalSet};
+use crate::ordinal::{Ordinal, OrdinalSet};
 use crate::time_unit::TimeUnitField;
 use std::borrow::Cow;
 

--- a/src/time_unit/days_of_week.rs
+++ b/src/time_unit/days_of_week.rs
@@ -1,5 +1,5 @@
 use crate::error::*;
-use crate::schedule::{Ordinal, OrdinalSet};
+use crate::ordinal::{Ordinal, OrdinalSet};
 use crate::time_unit::TimeUnitField;
 use std::borrow::Cow;
 

--- a/src/time_unit/hours.rs
+++ b/src/time_unit/hours.rs
@@ -1,4 +1,4 @@
-use crate::schedule::{Ordinal, OrdinalSet};
+use crate::ordinal::{Ordinal, OrdinalSet};
 use crate::time_unit::TimeUnitField;
 use std::borrow::Cow;
 

--- a/src/time_unit/minutes.rs
+++ b/src/time_unit/minutes.rs
@@ -1,4 +1,4 @@
-use crate::schedule::{Ordinal, OrdinalSet};
+use crate::ordinal::{Ordinal, OrdinalSet};
 use crate::time_unit::TimeUnitField;
 use std::borrow::Cow;
 

--- a/src/time_unit/mod.rs
+++ b/src/time_unit/mod.rs
@@ -15,7 +15,8 @@ pub use self::seconds::Seconds;
 pub use self::years::Years;
 
 use crate::error::*;
-use crate::schedule::{Ordinal, OrdinalSet, RootSpecifier, Specifier};
+use crate::ordinal::{Ordinal, OrdinalSet};
+use crate::schedule::{RootSpecifier, Specifier};
 use std::borrow::Cow;
 use std::collections::btree_set;
 use std::iter;

--- a/src/time_unit/mod.rs
+++ b/src/time_unit/mod.rs
@@ -16,7 +16,7 @@ pub use self::years::Years;
 
 use crate::error::*;
 use crate::ordinal::{Ordinal, OrdinalSet};
-use crate::schedule::{RootSpecifier, Specifier};
+use crate::specifier::{RootSpecifier, Specifier};
 use std::borrow::Cow;
 use std::collections::btree_set;
 use std::iter;

--- a/src/time_unit/months.rs
+++ b/src/time_unit/months.rs
@@ -1,5 +1,5 @@
 use crate::error::*;
-use crate::schedule::{Ordinal, OrdinalSet};
+use crate::ordinal::{Ordinal, OrdinalSet};
 use crate::time_unit::TimeUnitField;
 use std::borrow::Cow;
 

--- a/src/time_unit/seconds.rs
+++ b/src/time_unit/seconds.rs
@@ -1,4 +1,4 @@
-use crate::schedule::{Ordinal, OrdinalSet};
+use crate::ordinal::{Ordinal, OrdinalSet};
 use crate::time_unit::TimeUnitField;
 use std::borrow::Cow;
 

--- a/src/time_unit/years.rs
+++ b/src/time_unit/years.rs
@@ -1,4 +1,4 @@
-use crate::schedule::{Ordinal, OrdinalSet};
+use crate::ordinal::{Ordinal, OrdinalSet};
 use crate::time_unit::TimeUnitField;
 use std::borrow::Cow;
 


### PR DESCRIPTION
I was working in something else in the project and I was getting lost in the schedule.rs file a lot. I decided to refactor it to 5 different files.

It's not perfect (I had some problems extracting out parsing, I couldn't figure out how to get around a couple of clone() methods), but I thought it might help.

If you don't count the unit tests, every file is now under 400 lines long.