### PR TITLE
Option in TimeUnitField using lazy_static 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ name = "cron"
 [dependencies]
 chrono = "~0.4"
 nom = "~4.1"
+lazy_static="1.4.0"
 
 [dev-dependencies]
 chrono-tz = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ name = "cron"
 [dependencies]
 chrono = "~0.4"
 nom = "~4.1"
-lazy_static="1.4.0"
+once_cell = "1.5.2"
 
 [dev-dependencies]
 chrono-tz = "0.4"

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -82,7 +82,7 @@ where
                 ordinals.insert(T::validate_ordinal(ordinal)?);
             }
         }
-        Ok(T::from_ordinal_set(ordinals))
+        Ok(T::from_ordinal_set(Some(ordinals)))
     }
 }
 

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -77,7 +77,7 @@ where
     fn from_field(field: Field) -> Result<T, Error> {
         if field.specifiers.len() == 1 && 
             field.specifiers.get(0).unwrap() == &RootSpecifier::from(Specifier::All) 
-            { return Ok(T::from_ordinal_set(None)); }
+            { return Ok(T::all()); }
         let mut ordinals = OrdinalSet::new(); 
         for specifier in field.specifiers {
             let specifier_ordinals: OrdinalSet = T::ordinals_from_root_specifier(&specifier)?;
@@ -85,7 +85,7 @@ where
                 ordinals.insert(T::validate_ordinal(ordinal)?);
             }
         }
-        Ok(T::from_ordinal_set(Some(ordinals)))
+        Ok(T::from_ordinal_set(ordinals))
     }
 }
 

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -1,5 +1,5 @@
 use nom::{types::CompleteStr as Input, *};
-use std::iter::{self, Iterator};
+use std::iter::{Iterator};
 use std::str::{self, FromStr};
 
 use crate::error::{Error, ErrorKind};
@@ -75,7 +75,10 @@ where
     T: TimeUnitField,
 {
     fn from_field(field: Field) -> Result<T, Error> {
-        let mut ordinals = OrdinalSet::new(); // TODO:Combinator
+        if field.specifiers.len() == 1 && 
+            field.specifiers.get(0).unwrap() == &RootSpecifier::from(Specifier::All) 
+            { return Ok(T::from_ordinal_set(None)); }
+        let mut ordinals = OrdinalSet::new(); 
         for specifier in field.specifiers {
             let specifier_ordinals: OrdinalSet = T::ordinals_from_root_specifier(&specifier)?;
             for ordinal in specifier_ordinals {
@@ -210,10 +213,10 @@ named!(
     do_parse!(
         tag!("@monthly")
             >> (ScheduleFields::new(
-                Seconds::from_ordinal_set(iter::once(0).collect()),
-                Minutes::from_ordinal_set(iter::once(0).collect()),
-                Hours::from_ordinal_set(iter::once(0).collect()),
-                DaysOfMonth::from_ordinal_set(iter::once(1).collect()),
+                Seconds::from_ordinal(0),
+                Minutes::from_ordinal(0),
+                Hours::from_ordinal(0),
+                DaysOfMonth::from_ordinal(1),
                 Months::all(),
                 DaysOfWeek::all(),
                 Years::all()
@@ -226,12 +229,12 @@ named!(
     do_parse!(
         tag!("@weekly")
             >> (ScheduleFields::new(
-                Seconds::from_ordinal_set(iter::once(0).collect()),
-                Minutes::from_ordinal_set(iter::once(0).collect()),
-                Hours::from_ordinal_set(iter::once(0).collect()),
+                Seconds::from_ordinal(0),
+                Minutes::from_ordinal(0),
+                Hours::from_ordinal(0),
                 DaysOfMonth::all(),
                 Months::all(),
-                DaysOfWeek::from_ordinal_set(iter::once(1).collect()),
+                DaysOfWeek::from_ordinal(1),
                 Years::all()
             ))
     )
@@ -242,9 +245,9 @@ named!(
     do_parse!(
         tag!("@daily")
             >> (ScheduleFields::new(
-                Seconds::from_ordinal_set(iter::once(0).collect()),
-                Minutes::from_ordinal_set(iter::once(0).collect()),
-                Hours::from_ordinal_set(iter::once(0).collect()),
+                Seconds::from_ordinal(0),
+                Minutes::from_ordinal(0),
+                Hours::from_ordinal(0),
                 DaysOfMonth::all(),
                 Months::all(),
                 DaysOfWeek::all(),
@@ -258,8 +261,8 @@ named!(
     do_parse!(
         tag!("@hourly")
             >> (ScheduleFields::new(
-                Seconds::from_ordinal_set(iter::once(0).collect()),
-                Minutes::from_ordinal_set(iter::once(0).collect()),
+                Seconds::from_ordinal(0),
+                Minutes::from_ordinal(0),
                 Hours::all(),
                 DaysOfMonth::all(),
                 Months::all(),

--- a/src/time_unit/days_of_month.rs
+++ b/src/time_unit/days_of_month.rs
@@ -13,7 +13,7 @@ pub struct DaysOfMonth{
 }
 
 impl TimeUnitField for DaysOfMonth {
-    fn from_ordinal_set(ordinal_set: Option<OrdinalSet>) -> Self {
+    fn from_optional_ordinal_set(ordinal_set: Option<OrdinalSet>) -> Self {
         DaysOfMonth {
             ordinals: ordinal_set
         }

--- a/src/time_unit/days_of_month.rs
+++ b/src/time_unit/days_of_month.rs
@@ -1,13 +1,22 @@
 use crate::ordinal::{Ordinal, OrdinalSet};
 use crate::time_unit::TimeUnitField;
 use std::borrow::Cow;
+use lazy_static::lazy_static;
+
+lazy_static!{
+    static ref ALL: OrdinalSet = DaysOfMonth::all().ordinals.unwrap();
+}
 
 #[derive(Clone, Debug)]
-pub struct DaysOfMonth(OrdinalSet);
+pub struct DaysOfMonth{
+    ordinals: Option<OrdinalSet>
+}
 
 impl TimeUnitField for DaysOfMonth {
     fn from_ordinal_set(ordinal_set: OrdinalSet) -> Self {
-        DaysOfMonth(ordinal_set)
+        DaysOfMonth {
+            ordinals: Some(ordinal_set)
+        }
     }
     fn name() -> Cow<'static, str> {
         Cow::from("Days of Month")
@@ -19,6 +28,12 @@ impl TimeUnitField for DaysOfMonth {
         31
     }
     fn ordinals(&self) -> &OrdinalSet {
-        &self.0
+        match &self.ordinals {
+            Some(ordinal_set) => &ordinal_set,
+            None => &ALL
+        }
+    }
+    fn is_specified(&self) -> bool {
+        self.ordinals.is_some()
     }
 }

--- a/src/time_unit/days_of_month.rs
+++ b/src/time_unit/days_of_month.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 use lazy_static::lazy_static;
 
 lazy_static!{
-    static ref ALL: OrdinalSet = DaysOfMonth::all().ordinals.unwrap();
+    static ref ALL: OrdinalSet = DaysOfMonth::supported_ordinals();
 }
 
 #[derive(Clone, Debug)]
@@ -13,9 +13,9 @@ pub struct DaysOfMonth{
 }
 
 impl TimeUnitField for DaysOfMonth {
-    fn from_ordinal_set(ordinal_set: OrdinalSet) -> Self {
+    fn from_ordinal_set(ordinal_set: Option<OrdinalSet>) -> Self {
         DaysOfMonth {
-            ordinals: Some(ordinal_set)
+            ordinals: ordinal_set
         }
     }
     fn name() -> Cow<'static, str> {

--- a/src/time_unit/days_of_month.rs
+++ b/src/time_unit/days_of_month.rs
@@ -31,7 +31,4 @@ impl TimeUnitField for DaysOfMonth {
             None => &ALL
         }
     }
-    fn is_specified(&self) -> bool {
-        self.ordinals.is_some()
-    }
 }

--- a/src/time_unit/days_of_month.rs
+++ b/src/time_unit/days_of_month.rs
@@ -1,11 +1,9 @@
 use crate::ordinal::{Ordinal, OrdinalSet};
 use crate::time_unit::TimeUnitField;
 use std::borrow::Cow;
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 
-lazy_static!{
-    static ref ALL: OrdinalSet = DaysOfMonth::supported_ordinals();
-}
+static ALL: Lazy<OrdinalSet> = Lazy::new(|| { DaysOfMonth::supported_ordinals() });
 
 #[derive(Clone, Debug)]
 pub struct DaysOfMonth{

--- a/src/time_unit/days_of_week.rs
+++ b/src/time_unit/days_of_week.rs
@@ -14,7 +14,7 @@ pub struct DaysOfWeek{
 }
 
 impl TimeUnitField for DaysOfWeek {
-    fn from_ordinal_set(ordinal_set: Option<OrdinalSet>) -> Self {
+    fn from_optional_ordinal_set(ordinal_set: Option<OrdinalSet>) -> Self {
         DaysOfWeek{
             ordinals: ordinal_set
         }

--- a/src/time_unit/days_of_week.rs
+++ b/src/time_unit/days_of_week.rs
@@ -5,7 +5,7 @@ use std::borrow::Cow;
 use lazy_static::lazy_static;
 
 lazy_static!{
-    static ref ALL: OrdinalSet = DaysOfWeek::all().ordinals.unwrap();
+    static ref ALL: OrdinalSet = DaysOfWeek::supported_ordinals();
 }
 
 #[derive(Clone, Debug)]
@@ -14,9 +14,9 @@ pub struct DaysOfWeek{
 }
 
 impl TimeUnitField for DaysOfWeek {
-    fn from_ordinal_set(ordinal_set: OrdinalSet) -> Self {
+    fn from_ordinal_set(ordinal_set: Option<OrdinalSet>) -> Self {
         DaysOfWeek{
-            ordinals: Some(ordinal_set)
+            ordinals: ordinal_set
         }
     }
     fn name() -> Cow<'static, str> {

--- a/src/time_unit/days_of_week.rs
+++ b/src/time_unit/days_of_week.rs
@@ -2,13 +2,22 @@ use crate::error::*;
 use crate::ordinal::{Ordinal, OrdinalSet};
 use crate::time_unit::TimeUnitField;
 use std::borrow::Cow;
+use lazy_static::lazy_static;
+
+lazy_static!{
+    static ref ALL: OrdinalSet = DaysOfWeek::all().ordinals.unwrap();
+}
 
 #[derive(Clone, Debug)]
-pub struct DaysOfWeek(OrdinalSet);
+pub struct DaysOfWeek{
+    ordinals: Option<OrdinalSet>
+}
 
 impl TimeUnitField for DaysOfWeek {
     fn from_ordinal_set(ordinal_set: OrdinalSet) -> Self {
-        DaysOfWeek(ordinal_set)
+        DaysOfWeek{
+            ordinals: Some(ordinal_set)
+        }
     }
     fn name() -> Cow<'static, str> {
         Cow::from("Days of Week")
@@ -40,6 +49,12 @@ impl TimeUnitField for DaysOfWeek {
         Ok(ordinal)
     }
     fn ordinals(&self) -> &OrdinalSet {
-        &self.0
+        match &self.ordinals {
+            Some(ordinal_set) => &ordinal_set,
+            None => &ALL
+        }
+    }
+    fn is_specified(&self) -> bool {
+        self.ordinals.is_some()
     }
 }

--- a/src/time_unit/days_of_week.rs
+++ b/src/time_unit/days_of_week.rs
@@ -2,11 +2,9 @@ use crate::error::*;
 use crate::ordinal::{Ordinal, OrdinalSet};
 use crate::time_unit::TimeUnitField;
 use std::borrow::Cow;
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 
-lazy_static!{
-    static ref ALL: OrdinalSet = DaysOfWeek::supported_ordinals();
-}
+static ALL: Lazy<OrdinalSet> = Lazy::new(|| { DaysOfWeek::supported_ordinals() });
 
 #[derive(Clone, Debug)]
 pub struct DaysOfWeek{

--- a/src/time_unit/days_of_week.rs
+++ b/src/time_unit/days_of_week.rs
@@ -52,7 +52,4 @@ impl TimeUnitField for DaysOfWeek {
             None => &ALL
         }
     }
-    fn is_specified(&self) -> bool {
-        self.ordinals.is_some()
-    }
 }

--- a/src/time_unit/hours.rs
+++ b/src/time_unit/hours.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 use lazy_static::lazy_static;
 
 lazy_static!{
-    static ref ALL: OrdinalSet = Hours::all().ordinals.unwrap();
+    static ref ALL: OrdinalSet = Hours::supported_ordinals();
 }
 
 #[derive(Clone, Debug)]
@@ -13,9 +13,9 @@ pub struct Hours{
 }
 
 impl TimeUnitField for Hours {
-    fn from_ordinal_set(ordinal_set: OrdinalSet) -> Self {
+    fn from_ordinal_set(ordinal_set: Option<OrdinalSet>) -> Self {
         Hours{
-            ordinals: Some(ordinal_set)
+            ordinals: ordinal_set
         }
     }
     fn name() -> Cow<'static, str> {

--- a/src/time_unit/hours.rs
+++ b/src/time_unit/hours.rs
@@ -13,7 +13,7 @@ pub struct Hours{
 }
 
 impl TimeUnitField for Hours {
-    fn from_ordinal_set(ordinal_set: Option<OrdinalSet>) -> Self {
+    fn from_optional_ordinal_set(ordinal_set: Option<OrdinalSet>) -> Self {
         Hours{
             ordinals: ordinal_set
         }

--- a/src/time_unit/hours.rs
+++ b/src/time_unit/hours.rs
@@ -1,13 +1,22 @@
 use crate::ordinal::{Ordinal, OrdinalSet};
 use crate::time_unit::TimeUnitField;
 use std::borrow::Cow;
+use lazy_static::lazy_static;
+
+lazy_static!{
+    static ref ALL: OrdinalSet = Hours::all().ordinals.unwrap();
+}
 
 #[derive(Clone, Debug)]
-pub struct Hours(OrdinalSet);
+pub struct Hours{
+    ordinals: Option<OrdinalSet>
+}
 
 impl TimeUnitField for Hours {
     fn from_ordinal_set(ordinal_set: OrdinalSet) -> Self {
-        Hours(ordinal_set)
+        Hours{
+            ordinals: Some(ordinal_set)
+        }
     }
     fn name() -> Cow<'static, str> {
         Cow::from("Hours")
@@ -19,6 +28,12 @@ impl TimeUnitField for Hours {
         23
     }
     fn ordinals(&self) -> &OrdinalSet {
-        &self.0
+        match &self.ordinals {
+            Some(ordinal_set) => &ordinal_set,
+            None => &ALL
+        }
+    }
+    fn is_specified(&self) -> bool {
+        self.ordinals.is_some()
     }
 }

--- a/src/time_unit/hours.rs
+++ b/src/time_unit/hours.rs
@@ -1,11 +1,9 @@
 use crate::ordinal::{Ordinal, OrdinalSet};
 use crate::time_unit::TimeUnitField;
 use std::borrow::Cow;
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 
-lazy_static!{
-    static ref ALL: OrdinalSet = Hours::supported_ordinals();
-}
+static ALL: Lazy<OrdinalSet> = Lazy::new(|| { Hours::supported_ordinals() });
 
 #[derive(Clone, Debug)]
 pub struct Hours{

--- a/src/time_unit/hours.rs
+++ b/src/time_unit/hours.rs
@@ -31,7 +31,4 @@ impl TimeUnitField for Hours {
             None => &ALL
         }
     }
-    fn is_specified(&self) -> bool {
-        self.ordinals.is_some()
-    }
 }

--- a/src/time_unit/minutes.rs
+++ b/src/time_unit/minutes.rs
@@ -1,13 +1,22 @@
 use crate::ordinal::{Ordinal, OrdinalSet};
 use crate::time_unit::TimeUnitField;
 use std::borrow::Cow;
+use lazy_static::lazy_static;
+
+lazy_static!{
+    static ref ALL: OrdinalSet = Minutes::all().ordinals.unwrap();
+}
 
 #[derive(Clone, Debug)]
-pub struct Minutes(OrdinalSet);
+pub struct Minutes{
+    ordinals: Option<OrdinalSet>
+}
 
 impl TimeUnitField for Minutes {
     fn from_ordinal_set(ordinal_set: OrdinalSet) -> Self {
-        Minutes(ordinal_set)
+        Minutes{
+            ordinals: Some(ordinal_set)
+        }
     }
     fn name() -> Cow<'static, str> {
         Cow::from("Minutes")
@@ -19,6 +28,12 @@ impl TimeUnitField for Minutes {
         59
     }
     fn ordinals(&self) -> &OrdinalSet {
-        &self.0
+        match &self.ordinals {
+            Some(ordinal_set) => &ordinal_set,
+            None => &ALL
+        }
+    }
+    fn is_specified(&self) -> bool {
+        self.ordinals.is_some()
     }
 }

--- a/src/time_unit/minutes.rs
+++ b/src/time_unit/minutes.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 use lazy_static::lazy_static;
 
 lazy_static!{
-    static ref ALL: OrdinalSet = Minutes::all().ordinals.unwrap();
+    static ref ALL: OrdinalSet = Minutes::supported_ordinals();
 }
 
 #[derive(Clone, Debug)]
@@ -13,9 +13,9 @@ pub struct Minutes{
 }
 
 impl TimeUnitField for Minutes {
-    fn from_ordinal_set(ordinal_set: OrdinalSet) -> Self {
+    fn from_ordinal_set(ordinal_set: Option<OrdinalSet>) -> Self {
         Minutes{
-            ordinals: Some(ordinal_set)
+            ordinals: ordinal_set
         }
     }
     fn name() -> Cow<'static, str> {

--- a/src/time_unit/minutes.rs
+++ b/src/time_unit/minutes.rs
@@ -1,11 +1,9 @@
 use crate::ordinal::{Ordinal, OrdinalSet};
 use crate::time_unit::TimeUnitField;
 use std::borrow::Cow;
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 
-lazy_static!{
-    static ref ALL: OrdinalSet = Minutes::supported_ordinals();
-}
+static ALL: Lazy<OrdinalSet> = Lazy::new(|| { Minutes::supported_ordinals() });
 
 #[derive(Clone, Debug)]
 pub struct Minutes{

--- a/src/time_unit/minutes.rs
+++ b/src/time_unit/minutes.rs
@@ -13,7 +13,7 @@ pub struct Minutes{
 }
 
 impl TimeUnitField for Minutes {
-    fn from_ordinal_set(ordinal_set: Option<OrdinalSet>) -> Self {
+    fn from_optional_ordinal_set(ordinal_set: Option<OrdinalSet>) -> Self {
         Minutes{
             ordinals: ordinal_set
         }

--- a/src/time_unit/minutes.rs
+++ b/src/time_unit/minutes.rs
@@ -31,7 +31,4 @@ impl TimeUnitField for Minutes {
             None => &ALL
         }
     }
-    fn is_specified(&self) -> bool {
-        self.ordinals.is_some()
-    }
 }

--- a/src/time_unit/mod.rs
+++ b/src/time_unit/mod.rs
@@ -197,7 +197,8 @@ where
     }
 
     fn is_all(&self) -> bool {
-        self.is_all()
+        let max_supported_ordinals = Self::inclusive_max() - Self::inclusive_min() + 1;
+        self.ordinals().len() == max_supported_ordinals as usize
     }
 }
 
@@ -210,11 +211,6 @@ where
     fn inclusive_min() -> Ordinal;
     fn inclusive_max() -> Ordinal;
     fn ordinals(&self) -> &OrdinalSet;
-
-    fn is_all(&self) -> bool {
-        let max_supported_ordinals = Self::inclusive_max() - Self::inclusive_min() + 1;
-        self.ordinals().len() == max_supported_ordinals as usize
-    }
     
     fn from_ordinal(ordinal: Ordinal) -> Self {
         Self::from_ordinal_set(iter::once(ordinal).collect())

--- a/src/time_unit/mod.rs
+++ b/src/time_unit/mod.rs
@@ -263,7 +263,7 @@ where
         use self::Specifier::*;
         //println!("ordinals_from_specifier for {} => {:?}", Self::name(), specifier);
         match *specifier {
-            All => Ok(Self::supported_ordinals()),  // TODO: change to Self::ALL
+            All => Ok(Self::supported_ordinals()),
             Point(ordinal) => Ok((&[ordinal]).iter().cloned().collect()),
             Range(start, end) => {
                 match (Self::validate_ordinal(start), Self::validate_ordinal(end)) {

--- a/src/time_unit/mod.rs
+++ b/src/time_unit/mod.rs
@@ -187,20 +187,20 @@ pub trait TimeUnitField
 where
     Self: Sized,
 {
-    fn from_ordinal_set(ordinal_set: OrdinalSet) -> Self;
+    fn from_ordinal_set(ordinal_set: Option<OrdinalSet>) -> Self;
     fn name() -> Cow<'static, str>;
     fn inclusive_min() -> Ordinal;
     fn inclusive_max() -> Ordinal;
     fn ordinals(&self) -> &OrdinalSet;
     fn is_specified(&self) -> bool;
     fn from_ordinal(ordinal: Ordinal) -> Self {
-        Self::from_ordinal_set(iter::once(ordinal).collect())
+        Self::from_ordinal_set(Some(iter::once(ordinal).collect()))
     }
     fn supported_ordinals() -> OrdinalSet {
         (Self::inclusive_min()..Self::inclusive_max() + 1).collect()
     }
     fn all() -> Self {
-        Self::from_ordinal_set(Self::supported_ordinals())
+        Self::from_ordinal_set(None)
     }
     fn ordinal_from_name(name: &str) -> Result<Ordinal, Error> {
         Err(ErrorKind::Expression(format!(

--- a/src/time_unit/mod.rs
+++ b/src/time_unit/mod.rs
@@ -157,7 +157,7 @@ pub trait TimeUnitSpec {
     /// ```
     fn count(&self) -> u32;
 
-    /// Checks if this TimeUnitSpec defined as all possibilities (thus created with a '*', '?' or in the case of weekdays '1-7')
+    /// Checks if this TimeUnitSpec is defined as all possibilities (thus created with a '*', '?' or in the case of weekdays '1-7')
     /// # Example
     /// ```
     /// use cron::{Schedule,TimeUnitSpec};

--- a/src/time_unit/mod.rs
+++ b/src/time_unit/mod.rs
@@ -237,7 +237,7 @@ where
         use self::Specifier::*;
         //println!("ordinals_from_specifier for {} => {:?}", Self::name(), specifier);
         match *specifier {
-            All => Ok(Self::supported_ordinals()),
+            All => Ok(Self::supported_ordinals()),  // TODO: change to Self::ALL
             Point(ordinal) => Ok((&[ordinal]).iter().cloned().collect()),
             Range(start, end) => {
                 match (Self::validate_ordinal(start), Self::validate_ordinal(end)) {

--- a/src/time_unit/mod.rs
+++ b/src/time_unit/mod.rs
@@ -192,6 +192,7 @@ where
     fn inclusive_min() -> Ordinal;
     fn inclusive_max() -> Ordinal;
     fn ordinals(&self) -> &OrdinalSet;
+    fn is_specified(&self) -> bool;
     fn from_ordinal(ordinal: Ordinal) -> Self {
         Self::from_ordinal_set(iter::once(ordinal).collect())
     }

--- a/src/time_unit/mod.rs
+++ b/src/time_unit/mod.rs
@@ -205,21 +205,29 @@ pub trait TimeUnitField
 where
     Self: Sized,
 {
-    fn from_ordinal_set(ordinal_set: Option<OrdinalSet>) -> Self;
+    fn from_optional_ordinal_set(ordinal_set: Option<OrdinalSet>) -> Self;
     fn name() -> Cow<'static, str>;
     fn inclusive_min() -> Ordinal;
     fn inclusive_max() -> Ordinal;
     fn ordinals(&self) -> &OrdinalSet;
     fn is_specified(&self) -> bool;
+    
     fn from_ordinal(ordinal: Ordinal) -> Self {
-        Self::from_ordinal_set(Some(iter::once(ordinal).collect()))
+        Self::from_ordinal_set(iter::once(ordinal).collect())
     }
+    
     fn supported_ordinals() -> OrdinalSet {
         (Self::inclusive_min()..Self::inclusive_max() + 1).collect()
-    }
+    }    
+    
     fn all() -> Self {
-        Self::from_ordinal_set(None)
+        Self::from_optional_ordinal_set(None)
     }
+    
+    fn from_ordinal_set(ordinal_set: OrdinalSet) -> Self {
+        Self::from_optional_ordinal_set(Some(ordinal_set))
+    }
+    
     fn ordinal_from_name(name: &str) -> Result<Ordinal, Error> {
         Err(ErrorKind::Expression(format!(
             "The '{}' field does not support using names. '{}' \

--- a/src/time_unit/mod.rs
+++ b/src/time_unit/mod.rs
@@ -157,7 +157,7 @@ pub trait TimeUnitSpec {
     /// ```
     fn count(&self) -> u32;
 
-    /// Checks if this TimeUnitSpec is specified (thus not created with a *)
+    /// Checks if this TimeUnitSpec defined as all possibilities (thus created with a '*', '?' or in the case of weekdays '1-7')
     /// # Example
     /// ```
     /// use cron::{Schedule,TimeUnitSpec};
@@ -166,10 +166,10 @@ pub trait TimeUnitSpec {
     /// let expression = "* * * 1,15 * * *";
     /// let schedule = Schedule::from_str(expression).expect("Failed to parse expression.");
     ///
-    /// assert_eq!(true, schedule.days_of_month().is_specified());
-    /// assert_eq!(false, schedule.months().is_specified());
+    /// assert_eq!(false, schedule.days_of_month().is_all());
+    /// assert_eq!(true, schedule.months().is_all());
     /// ```
-    fn is_specified(&self) -> bool;
+    fn is_all(&self) -> bool;
 }
 
 impl<T> TimeUnitSpec for T
@@ -196,8 +196,8 @@ where
         self.ordinals().len() as u32
     }
 
-    fn is_specified(&self) -> bool {
-        self.is_specified()
+    fn is_all(&self) -> bool {
+        self.is_all()
     }
 }
 
@@ -210,7 +210,11 @@ where
     fn inclusive_min() -> Ordinal;
     fn inclusive_max() -> Ordinal;
     fn ordinals(&self) -> &OrdinalSet;
-    fn is_specified(&self) -> bool;
+
+    fn is_all(&self) -> bool {
+        let max_supported_ordinals = Self::inclusive_max() - Self::inclusive_min() + 1;
+        self.ordinals().len() == max_supported_ordinals as usize
+    }
     
     fn from_ordinal(ordinal: Ordinal) -> Self {
         Self::from_ordinal_set(iter::once(ordinal).collect())

--- a/src/time_unit/mod.rs
+++ b/src/time_unit/mod.rs
@@ -156,6 +156,20 @@ pub trait TimeUnitSpec {
     /// assert_eq!(2, schedule.days_of_month().count());
     /// ```
     fn count(&self) -> u32;
+
+    /// Checks if this TimeUnitSpec is specified (thus not created with a *)
+    /// # Example
+    /// ```
+    /// use cron::{Schedule,TimeUnitSpec};
+    /// use std::str::FromStr;
+    ///
+    /// let expression = "* * * 1,15 * * *";
+    /// let schedule = Schedule::from_str(expression).expect("Failed to parse expression.");
+    ///
+    /// assert_eq!(true, schedule.days_of_month().is_specified());
+    /// assert_eq!(false, schedule.months().is_specified());
+    /// ```
+    fn is_specified(&self) -> bool;
 }
 
 impl<T> TimeUnitSpec for T
@@ -180,6 +194,10 @@ where
     }
     fn count(&self) -> u32 {
         self.ordinals().len() as u32
+    }
+
+    fn is_specified(&self) -> bool {
+        self.is_specified()
     }
 }
 

--- a/src/time_unit/months.rs
+++ b/src/time_unit/months.rs
@@ -14,7 +14,7 @@ pub struct Months{
 }
 
 impl TimeUnitField for Months {
-    fn from_ordinal_set(ordinal_set: Option<OrdinalSet>) -> Self {
+    fn from_optional_ordinal_set(ordinal_set: Option<OrdinalSet>) -> Self {
         Months{
             ordinals: ordinal_set
         }

--- a/src/time_unit/months.rs
+++ b/src/time_unit/months.rs
@@ -55,7 +55,4 @@ impl TimeUnitField for Months {
             None => &ALL
         }
     }
-    fn is_specified(&self) -> bool {
-        self.ordinals.is_some()
-    }
 }

--- a/src/time_unit/months.rs
+++ b/src/time_unit/months.rs
@@ -2,11 +2,9 @@ use crate::error::*;
 use crate::ordinal::{Ordinal, OrdinalSet};
 use crate::time_unit::TimeUnitField;
 use std::borrow::Cow;
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 
-lazy_static!{
-    static ref ALL: OrdinalSet = Months::supported_ordinals();
-}
+static ALL: Lazy<OrdinalSet> = Lazy::new(|| { Months::supported_ordinals() });
 
 #[derive(Clone, Debug)]
 pub struct Months{

--- a/src/time_unit/months.rs
+++ b/src/time_unit/months.rs
@@ -5,7 +5,7 @@ use std::borrow::Cow;
 use lazy_static::lazy_static;
 
 lazy_static!{
-    static ref ALL: OrdinalSet = Months::all().ordinals.unwrap();
+    static ref ALL: OrdinalSet = Months::supported_ordinals();
 }
 
 #[derive(Clone, Debug)]
@@ -14,9 +14,9 @@ pub struct Months{
 }
 
 impl TimeUnitField for Months {
-    fn from_ordinal_set(ordinal_set: OrdinalSet) -> Self {
+    fn from_ordinal_set(ordinal_set: Option<OrdinalSet>) -> Self {
         Months{
-            ordinals: Some(ordinal_set)
+            ordinals: ordinal_set
         }
     }
     fn name() -> Cow<'static, str> {

--- a/src/time_unit/months.rs
+++ b/src/time_unit/months.rs
@@ -2,13 +2,22 @@ use crate::error::*;
 use crate::ordinal::{Ordinal, OrdinalSet};
 use crate::time_unit::TimeUnitField;
 use std::borrow::Cow;
+use lazy_static::lazy_static;
+
+lazy_static!{
+    static ref ALL: OrdinalSet = Months::all().ordinals.unwrap();
+}
 
 #[derive(Clone, Debug)]
-pub struct Months(OrdinalSet);
+pub struct Months{
+    ordinals: Option<OrdinalSet>
+}
 
 impl TimeUnitField for Months {
     fn from_ordinal_set(ordinal_set: OrdinalSet) -> Self {
-        Months(ordinal_set)
+        Months{
+            ordinals: Some(ordinal_set)
+        }
     }
     fn name() -> Cow<'static, str> {
         Cow::from("Months")
@@ -43,6 +52,12 @@ impl TimeUnitField for Months {
         Ok(ordinal)
     }
     fn ordinals(&self) -> &OrdinalSet {
-        &self.0
+        match &self.ordinals {
+            Some(ordinal_set) => &ordinal_set,
+            None => &ALL
+        }
+    }
+    fn is_specified(&self) -> bool {
+        self.ordinals.is_some()
     }
 }

--- a/src/time_unit/seconds.rs
+++ b/src/time_unit/seconds.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 use lazy_static::lazy_static;
 
 lazy_static!{
-    static ref ALL: OrdinalSet = Seconds::all().ordinals.unwrap();
+    static ref ALL: OrdinalSet = Seconds::supported_ordinals();
 }
 
 #[derive(Clone, Debug)]
@@ -13,9 +13,9 @@ pub struct Seconds {
 }
 
 impl TimeUnitField for Seconds {
-    fn from_ordinal_set(ordinal_set: OrdinalSet) -> Self {
+    fn from_ordinal_set(ordinal_set: Option<OrdinalSet>) -> Self {
         Seconds{
-            ordinals: Some(ordinal_set)
+            ordinals: ordinal_set
         }
     }
     fn name() -> Cow<'static, str> {

--- a/src/time_unit/seconds.rs
+++ b/src/time_unit/seconds.rs
@@ -1,11 +1,9 @@
 use crate::ordinal::{Ordinal, OrdinalSet};
 use crate::time_unit::TimeUnitField;
 use std::borrow::Cow;
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 
-lazy_static!{
-    static ref ALL: OrdinalSet = Seconds::supported_ordinals();
-}
+static ALL: Lazy<OrdinalSet> = Lazy::new(|| { Seconds::supported_ordinals() });
 
 #[derive(Clone, Debug)]
 pub struct Seconds {

--- a/src/time_unit/seconds.rs
+++ b/src/time_unit/seconds.rs
@@ -31,7 +31,4 @@ impl TimeUnitField for Seconds {
             None => &ALL
         }
     }
-    fn is_specified(&self) -> bool {
-        self.ordinals.is_some()
-    }
 }

--- a/src/time_unit/seconds.rs
+++ b/src/time_unit/seconds.rs
@@ -1,13 +1,22 @@
 use crate::ordinal::{Ordinal, OrdinalSet};
 use crate::time_unit::TimeUnitField;
 use std::borrow::Cow;
+use lazy_static::lazy_static;
+
+lazy_static!{
+    static ref ALL: OrdinalSet = Seconds::all().ordinals.unwrap();
+}
 
 #[derive(Clone, Debug)]
-pub struct Seconds(OrdinalSet);
+pub struct Seconds {
+    ordinals: Option<OrdinalSet>
+}
 
 impl TimeUnitField for Seconds {
     fn from_ordinal_set(ordinal_set: OrdinalSet) -> Self {
-        Seconds(ordinal_set)
+        Seconds{
+            ordinals: Some(ordinal_set)
+        }
     }
     fn name() -> Cow<'static, str> {
         Cow::from("Seconds")
@@ -19,6 +28,12 @@ impl TimeUnitField for Seconds {
         59
     }
     fn ordinals(&self) -> &OrdinalSet {
-        &self.0
+        match &self.ordinals {
+            Some(ordinal_set) => &ordinal_set,
+            None => &ALL
+        }
+    }
+    fn is_specified(&self) -> bool {
+        self.ordinals.is_some()
     }
 }

--- a/src/time_unit/seconds.rs
+++ b/src/time_unit/seconds.rs
@@ -13,7 +13,7 @@ pub struct Seconds {
 }
 
 impl TimeUnitField for Seconds {
-    fn from_ordinal_set(ordinal_set: Option<OrdinalSet>) -> Self {
+    fn from_optional_ordinal_set(ordinal_set: Option<OrdinalSet>) -> Self {
         Seconds{
             ordinals: ordinal_set
         }

--- a/src/time_unit/years.rs
+++ b/src/time_unit/years.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 use lazy_static::lazy_static;
 
 lazy_static!{
-    static ref ALL: OrdinalSet = Years::all().ordinals.unwrap();
+    static ref ALL: OrdinalSet = Years::supported_ordinals();
 }
 
 #[derive(Clone, Debug)]
@@ -13,9 +13,9 @@ pub struct Years{
 }
 
 impl TimeUnitField for Years {
-    fn from_ordinal_set(ordinal_set: OrdinalSet) -> Self {
+    fn from_ordinal_set(ordinal_set: Option<OrdinalSet>) -> Self {
         Years{
-            ordinals: Some(ordinal_set)
+            ordinals: ordinal_set
         }
     }
     fn name() -> Cow<'static, str> {

--- a/src/time_unit/years.rs
+++ b/src/time_unit/years.rs
@@ -1,11 +1,9 @@
 use crate::ordinal::{Ordinal, OrdinalSet};
 use crate::time_unit::TimeUnitField;
 use std::borrow::Cow;
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 
-lazy_static!{
-    static ref ALL: OrdinalSet = Years::supported_ordinals();
-}
+static ALL: Lazy<OrdinalSet> = Lazy::new(|| { Years::supported_ordinals() });
 
 #[derive(Clone, Debug)]
 pub struct Years{

--- a/src/time_unit/years.rs
+++ b/src/time_unit/years.rs
@@ -34,7 +34,4 @@ impl TimeUnitField for Years {
             None => &ALL
         }
     }
-    fn is_specified(&self) -> bool {
-        self.ordinals.is_some()
-    }
 }

--- a/src/time_unit/years.rs
+++ b/src/time_unit/years.rs
@@ -13,7 +13,7 @@ pub struct Years{
 }
 
 impl TimeUnitField for Years {
-    fn from_ordinal_set(ordinal_set: Option<OrdinalSet>) -> Self {
+    fn from_optional_ordinal_set(ordinal_set: Option<OrdinalSet>) -> Self {
         Years{
             ordinals: ordinal_set
         }

--- a/src/time_unit/years.rs
+++ b/src/time_unit/years.rs
@@ -1,13 +1,22 @@
 use crate::ordinal::{Ordinal, OrdinalSet};
 use crate::time_unit::TimeUnitField;
 use std::borrow::Cow;
+use lazy_static::lazy_static;
+
+lazy_static!{
+    static ref ALL: OrdinalSet = Years::all().ordinals.unwrap();
+}
 
 #[derive(Clone, Debug)]
-pub struct Years(OrdinalSet);
+pub struct Years{
+    ordinals: Option<OrdinalSet>
+}
 
 impl TimeUnitField for Years {
     fn from_ordinal_set(ordinal_set: OrdinalSet) -> Self {
-        Years(ordinal_set)
+        Years{
+            ordinals: Some(ordinal_set)
+        }
     }
     fn name() -> Cow<'static, str> {
         Cow::from("Years")
@@ -22,6 +31,12 @@ impl TimeUnitField for Years {
         2100
     }
     fn ordinals(&self) -> &OrdinalSet {
-        &self.0
+        match &self.ordinals {
+            Some(ordinal_set) => &ordinal_set,
+            None => &ALL
+        }
+    }
+    fn is_specified(&self) -> bool {
+        self.ordinals.is_some()
     }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -498,14 +498,14 @@ mod tests {
     }
 
     #[test]
-    fn test_is_specified() {
+    fn test_is_all() {
         let schedule = Schedule::from_str("* * * 1,15 * * *").unwrap();
-        assert!(!schedule.years().is_specified());
-        assert!(schedule.days_of_month().is_specified());
-        assert!(!schedule.days_of_week().is_specified());
-        assert!(!schedule.months().is_specified());
-        assert!(!schedule.hours().is_specified());
-        assert!(!schedule.minutes().is_specified());
-        assert!(!schedule.seconds().is_specified());
+        assert!(schedule.years().is_all());
+        assert!(!schedule.days_of_month().is_all());
+        assert!(schedule.days_of_week().is_all());
+        assert!(schedule.months().is_all());
+        assert!(schedule.hours().is_all());
+        assert!(schedule.minutes().is_all());
+        assert!(schedule.seconds().is_all());
     }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -499,11 +499,11 @@ mod tests {
 
     #[test]
     fn test_is_all() {
-        let schedule = Schedule::from_str("0-59 * 0-23 1,15 * ? *").unwrap();
+        let schedule = Schedule::from_str("0-59 * 0-23 ?/2 1,2-4 ? *").unwrap();
         assert!(schedule.years().is_all());
         assert!(!schedule.days_of_month().is_all());
         assert!(schedule.days_of_week().is_all());
-        assert!(schedule.months().is_all());
+        assert!(!schedule.months().is_all());
         assert!(schedule.hours().is_all());
         assert!(schedule.minutes().is_all());
         assert!(schedule.seconds().is_all());

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -496,4 +496,16 @@ mod tests {
             assert_eq!(*expected_value, schedule_iter.next().unwrap());
         }
     }
+
+    #[test]
+    fn test_is_specified() {
+        let schedule = Schedule::from_str("* * * 1,15 * * *").unwrap();
+        assert!(!schedule.years().is_specified());
+        assert!(schedule.days_of_month().is_specified());
+        assert!(!schedule.days_of_week().is_specified());
+        assert!(!schedule.months().is_specified());
+        assert!(!schedule.hours().is_specified());
+        assert!(!schedule.minutes().is_specified());
+        assert!(!schedule.seconds().is_specified());
+    }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -499,7 +499,7 @@ mod tests {
 
     #[test]
     fn test_is_all() {
-        let schedule = Schedule::from_str("* * * 1,15 * * *").unwrap();
+        let schedule = Schedule::from_str("0-59 * 0-23 1,15 * ? *").unwrap();
         assert!(schedule.years().is_all());
         assert!(!schedule.days_of_month().is_all());
         assert!(schedule.days_of_week().is_all());


### PR DESCRIPTION
Same as #73 Just cleaned up the git mess.

Changes the internals of all TimeUnitFields to be optional. If the `TimeUnitField` specified, then its populated with an `OrdinalSet`. If it's not specified (the cron field is *) then it's None. If then the the `OrdinalSet` is requested, it will simply return a reference to a static `OrdinalSet` that is filled using `[TimeUnitField]::supported_ordinals()`. `TimeUnitField::all()` will create a TimeUnitField that will point to this static set.

TimeUnitSpec gains an extra function: `is_specified()`

I've chosen to populate this set lazily, but I had to make it statically, because the following code simply doesn't work:
```rust
fn ordinals(&self) -> &OrdinalSet {
        &self.0
        match &self.ordinals {
            Some(ordinal_set) => &ordinal_set,
            None => &self::all() // Can't return this reference, needs to be a static reference.
        }
    }
```

Lastly I cleaned up some small stuff in parsing.rs

`Seconds::from_ordinal_set(iter::once(0).collect())` becomes `Seconds::from_ordinal(0)` (etc.)