### PR TITLE
Remove dependency on time from chrono.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 name = "cron"
 
 [dependencies]
-chrono = "~0.4"
+chrono = { version = "~0.4", default-features = false, features = ["clock"] }
 nom = "~7"
 once_cell = "1.5.2"
 


### PR DESCRIPTION
It would be good to get rid of the time dependency pulled in by chrono because: a) https://rustsec.org/advisories/RUSTSEC-2020-0071 and b) it's not needed.