### PR TITLE
Dep updates and Clippy fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ name = "cron"
 [dependencies]
 chrono = { version = "~0.4", default-features = false, features = ["clock"] }
 nom = "~7"
-once_cell = "1.5.2"
+once_cell = "1.10"
 
 [dev-dependencies]
-chrono-tz = "0.4"
+chrono-tz = "~0.6"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![deny(rust_2018_idioms)]
-#![deny(broken_intra_doc_links)]
+#![deny(rustdoc::broken_intra_doc_links)]
 
+#![allow(clippy::needless_doctest_main)]
 //! A cron expression parser and schedule explorer
 //! # Example
 //! ```


### PR DESCRIPTION
- Updated `chrono-tz` to version 0.6, this fully removes all time dependencies.
- Update `once_cell` to version 1.10, no major changes done, and works fine.
- Updated lint deny to new format
- Added clippy allow for needless_doctest_main

This will fully remove any (dev-)dependency for the time crate and it
also gets rid of warnings generated during `cargo test` or `cargo clippy`