### PR TITLE
Fix backwards iteration when inital time has milliseconds

### DIFF
--- a/src/queries.rs
+++ b/src/queries.rs
@@ -120,8 +120,13 @@ where
     Z: TimeZone,
 {
     pub fn from(before: &DateTime<Z>) -> PrevFromQuery<Z> {
+        let initial_datetime = if before.timestamp_subsec_millis() > 0 {
+            before.clone()
+        } else {
+            before.clone() - Duration::seconds(1)
+        };
         PrevFromQuery {
-            initial_datetime: before.clone() - Duration::seconds(1),
+            initial_datetime,
             first_month: true,
             first_day_of_month: true,
             first_hour: true,

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -456,8 +456,10 @@ fn days_in_month(month: Ordinal, year: Ordinal) -> u32 {
 
 #[cfg(test)]
 mod test {
+    use chrono::Duration;
+
     use super::*;
-    use std::str::{FromStr};
+    use std::str::FromStr;
 
     #[test]
     fn test_next_and_prev_from() {
@@ -476,6 +478,11 @@ mod test {
         println!("PREV FROM for {} {:?}", expression, prev);
         assert!(prev.is_some());
         assert_eq!(prev, next);
+
+        let prev2 = schedule.prev_from(&(next2.unwrap() + Duration::milliseconds(100)));
+        println!("PREV2 FROM for {} {:?}", expression, prev2);
+        assert!(prev2.is_some());
+        assert_eq!(prev2, next2);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Let's say the schedule is `0 * * * * *`.

 - Iterating the schedule before `12:00:05.000` should yield `12:00:04.000`
 - However, iterating the schedule before `12:00:05.100` should start at `12:00:05.000`.  (notice the milliseconds are >0) 

This commit fixes the second case which was yielding `12:00:04.000`.