### PR TITLE
Add `serde` compatibility for type `Schedule`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,13 @@ name = "cron"
 chrono = { version = "~0.4", default-features = false, features = ["clock"] }
 nom = "~7"
 once_cell = "1.10"
+serde = {version = "1.0.164", optional = true }
 
 [dev-dependencies]
 chrono-tz = "~0.6"
+serde_test = "1.0.164"
+
+[features]
+serde = ["dep:serde"]
+
+


### PR DESCRIPTION
[x] Unit Tests included
[x] Added `serde`-Feature as an optional feature