### PR TITLE
fix: Don't accept invalid step for `Period`

### DIFF
--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -76,21 +76,6 @@ where
         }
         let mut ordinals = OrdinalSet::new();
         for specifier in field.specifiers {
-            if let RootSpecifier::Period(_, interval) = specifier {
-                // Having an interval of 0 is not valid and at the same time, having intervals
-                // below 1970 is valid for years so instead of using `validate_ordinal` for the
-                // interval we allow 1-<inclusive max>.
-                if interval < 1 || interval > T::inclusive_max() {
-                    return Err(ErrorKind::Expression(format!(
-                        "{} must be between 1 and {}. ('{}' specified.)",
-                        Self::name(),
-                        Self::inclusive_max(),
-                        interval,
-                    ))
-                    .into());
-                }
-            }
-
             let specifier_ordinals: OrdinalSet = T::ordinals_from_root_specifier(&specifier)?;
             for ordinal in specifier_ordinals {
                 ordinals.insert(T::validate_ordinal(ordinal)?);

--- a/src/time_unit/mod.rs
+++ b/src/time_unit/mod.rs
@@ -301,6 +301,16 @@ where
                 "range step cannot be zero".to_string(),
             ))?,
             RootSpecifier::Period(start, step) => {
+                if *step < 1 || *step > Self::inclusive_max() {
+                    return Err(ErrorKind::Expression(format!(
+                        "{} must be between 1 and {}. ('{}' specified.)",
+                        Self::name(),
+                        Self::inclusive_max(),
+                        step,
+                    ))
+                    .into());
+                }
+
                 let base_set = match start {
                     // A point prior to a period implies a range whose start is the specified
                     // point and terminating inclusively with the inclusive max


### PR DESCRIPTION
If the specifier is a period specifier, ensure that the interval is larger than 0 (0 would be every 0th) and less than the max value for the unit.

Resolves #59 