### PR TITLE
Make `next_after` a public API

### DIFF
--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -31,7 +31,7 @@ impl Schedule {
         }
     }
 
-    fn next_after<Z>(&self, after: &DateTime<Z>) -> Option<DateTime<Z>>
+    pub fn next_after<Z>(&self, after: &DateTime<Z>) -> Option<DateTime<Z>>
     where
         Z: TimeZone,
     {


### PR DESCRIPTION
On of the typical use cases for the cron library is to calculate the next execution point given a point in time.

The library already has the functionality, but it's not exposed to the public.

This MR enables that.

if it is ok for you it would be great to have this change merged.

Thanks!