### PR TITLE
feat: implement optimized `Serialize` and `Deserialize` for `Schedule`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,9 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build
       run: cargo build --verbose
-    - name: Run tests
+    - name: Run tests (default features)
       run: cargo test --verbose
+    - name: Run tests (all features)
+      run: cargo test --verbose --all-features
     - name: Build docs
       run: cargo doc --no-deps --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,13 @@ name = "cron"
 chrono = { version = "~0.4", default-features = false, features = ["clock"] }
 nom = "~7"
 once_cell = "1.10"
+serde = {version = "1.0.164", optional = true }
 
 [dev-dependencies]
 chrono-tz = "~0.6"
+serde_test = "1.0.164"
+
+[features]
+serde = ["dep:serde"]
+
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,11 @@ serde = {version = "1.0.164", optional = true }
 chrono-tz = "~0.6"
 serde_test = "1.0.164"
 
+# Dev-dependency for feature "serde".
+# Optional dev-dependencies are not supported yet.
+# Cargo feature request is available at https://github.com/rust-lang/cargo/issues/1596
+postcard = { version = "1.0.10", default-features = false, features = ["use-std"] }
+
 [features]
 serde = ["dep:serde"]
 

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -2,7 +2,6 @@ use chrono::offset::TimeZone;
 use chrono::{DateTime, Datelike, Timelike, Utc};
 use std::fmt::{Display, Formatter, Result as FmtResult};
 use std::ops::Bound::{Included, Unbounded};
-use std::str::FromStr;
 
 #[cfg(feature = "serde")]
 use core::fmt;
@@ -12,10 +11,6 @@ use serde::{
     Deserialize, Serialize, Serializer,
 };
 
-#[cfg(test)]
-use serde_test::{assert_tokens, Token};
-
-use crate::error::Error;
 use crate::ordinal::*;
 use crate::queries::*;
 use crate::time_unit::*;
@@ -364,6 +359,11 @@ impl Schedule {
     pub fn timeunitspec_eq(&self, other: &Schedule) -> bool {
         self.fields == other.fields
     }
+
+    /// Returns a reference to the source cron expression.
+    pub fn source(&self) -> &str {
+        &self.source
+    }
 }
 
 impl Display for Schedule {
@@ -546,21 +546,28 @@ impl<'de> Visitor<'de> for ScheduleVisitor {
         formatter.write_str("a valid cron expression")
     }
 
-    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-    where
-        E: de::Error,
-    {
-        match Schedule::from_str(v) {
-            Ok(value) => Ok(value.into()),
-            Err(err) => Err(de::Error::custom(err)),
-        }
-    }
-
+    // Supporting `Deserializer`s shall provide an owned `String`.
+    //
+    // The `Schedule` will decode from a `&str` to it,
+    // then store the owned `String` as `Schedule::source`.
     fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
     where
         E: de::Error,
     {
-        self.visit_str(&v)
+        Schedule::try_from(v).map_err(de::Error::custom)
+    }
+
+    // `Deserializer`s not providing an owned `String`
+    // shall provide a `&str`.
+    //
+    // The `Schedule` will decode from the `&str`,
+    // then clone into the heap to store as an owned `String`
+    // as `Schedule::source`.
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Schedule::try_from(v).map_err(de::Error::custom)
     }
 }
 
@@ -570,7 +577,7 @@ impl Serialize for Schedule {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        serializer.serialize_str(self.source())
     }
 }
 
@@ -580,6 +587,15 @@ impl<'de> Deserialize<'de> for Schedule {
     where
         D: serde::Deserializer<'de>,
     {
+        // Hint that the `Deserialize` type `Schedule`
+        // would benefit from taking ownership of
+        // buffered data owned by the `Deserializer`:
+        //
+        // The deserialization "happy path" decodes from a `&str`,
+        // then stores the source as owned `String`.
+        //
+        // Thus, the optimized happy path receives an owned `String`
+        // if the `Deserializer` in use supports providing one.
         deserializer.deserialize_string(ScheduleVisitor)
     }
 }
@@ -587,6 +603,8 @@ impl<'de> Deserialize<'de> for Schedule {
 #[cfg(test)]
 mod test {
     use chrono::Duration;
+    #[cfg(feature = "serde")]
+    use serde_test::{assert_tokens, Token};
 
     use super::*;
     use std::str::FromStr;

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -611,14 +611,14 @@ mod test {
 
     #[cfg(feature = "serde")]
     #[test]
-    fn test_ser_de_schedule() {
-        let cron_value = Schedule::from_str("* * * * * * *").expect("Valid Format");
-        assert_tokens(&cron_value, &[Token::String("* * * * * * *")])
+    fn test_ser_de_schedule_tokens() {
+        let schedule = Schedule::from_str("* * * * * * *").expect("valid format");
+        assert_tokens(&schedule, &[Token::String("* * * * * * *")])
     }
 
     #[cfg(feature = "serde")]
     #[test]
-    fn test_invalid_ser_de_schedule() {
+    fn test_invalid_ser_de_schedule_tokens() {
         use serde_test::assert_de_tokens_error;
 
         assert_de_tokens_error::<Schedule>(

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -537,6 +537,7 @@ fn days_in_month(month: Ordinal, year: Ordinal) -> u32 {
 
 #[cfg(feature = "serde")]
 struct ScheduleVisitor;
+
 #[cfg(feature = "serde")]
 impl<'de> Visitor<'de> for ScheduleVisitor {
     type Value = Schedule;
@@ -573,6 +574,7 @@ impl Serialize for Schedule {
     }
 }
 
+#[cfg(feature = "serde")]
 impl<'de> Deserialize<'de> for Schedule {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -2,7 +2,20 @@ use chrono::offset::TimeZone;
 use chrono::{DateTime, Datelike, Timelike, Utc};
 use std::fmt::{Display, Formatter, Result as FmtResult};
 use std::ops::Bound::{Included, Unbounded};
+use std::str::FromStr;
 
+#[cfg(feature = "serde")]
+use core::fmt;
+#[cfg(feature = "serde")]
+use serde::{
+    de::{self, Visitor},
+    Deserialize, Serialize, Serializer,
+};
+
+#[cfg(test)]
+use serde_test::{assert_tokens, Token};
+
+use crate::error::Error;
 use crate::ordinal::*;
 use crate::queries::*;
 use crate::time_unit::*;
@@ -522,12 +535,79 @@ fn days_in_month(month: Ordinal, year: Ordinal) -> u32 {
     }
 }
 
+#[cfg(feature = "serde")]
+struct ScheduleVisitor;
+#[cfg(feature = "serde")]
+impl<'de> Visitor<'de> for ScheduleVisitor {
+    type Value = Schedule;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a valid cron expression")
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        match Schedule::from_str(v) {
+            Ok(value) => Ok(value.into()),
+            Err(err) => Err(de::Error::custom(err)),
+        }
+    }
+
+    fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.visit_str(&v)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl Serialize for Schedule {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for Schedule {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_string(ScheduleVisitor)
+    }
+}
+
 #[cfg(test)]
 mod test {
     use chrono::Duration;
 
     use super::*;
     use std::str::FromStr;
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_ser_de_schedule() {
+        let cron_value = Schedule::from_str("* * * * * * *").expect("Valid Format");
+        assert_tokens(&cron_value, &[Token::String("* * * * * * *")])
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_invalid_ser_de_schedule() {
+        use serde_test::assert_de_tokens_error;
+
+        assert_de_tokens_error::<Schedule>(
+            &[Token::String(
+                "definitively an invalid value for a cron schedule!",
+            )],
+            "Invalid expression: Invalid cron expression.",
+        );
+    }
 
     #[test]
     fn test_next_and_prev_from() {
@@ -556,9 +636,7 @@ mod test {
     #[test]
     fn test_next_after_past_date_next_year() {
         // Schedule after 2021-10-27
-        let starting_point = Utc
-            .with_ymd_and_hms(2021, 10, 27, 0, 0, 0)
-            .unwrap();
+        let starting_point = Utc.with_ymd_and_hms(2021, 10, 27, 0, 0, 0).unwrap();
 
         // Triggers on 2022-06-01. Note that the month and day are smaller than
         // the month and day in `starting_point`.


### PR DESCRIPTION
# Scope

This PR is meant to supersede #118.

Its goal is to implement `serde`'s `Serialize` and `Deserialize` for `Schedule`.

This feature request has been mentioned in https://github.com/zslayton/cron/issues/67#issuecomment-1514514631 but is not otherwise recorded in the project issues.

# Commits

## 45115e1f31fad86a7c84530539e8fdd77accca55 &mdash; [Add Serde compatiblity for type Schedule](https://github.com/zslayton/cron/commit/45115e1f31fad86a7c84530539e8fdd77accca55)

This is a rebase of #118 by @max-huster onto the current `master`.

## abdb52515aeceba7a11ca716161f434dc51094c6 &mdash; [fix: impl Deserialize behind feature gate](https://github.com/zslayton/cron/commit/abdb52515aeceba7a11ca716161f434dc51094c6)

This change fixes #118 by guarding `impl Deserialize for Schedule` behind the `"serde"` feature flag.

## 7520221e187c8a0473502c6d3ee367e1e14b6433 &mdash; [feat: implement optimized `Serialize` and `Deserialize` for `Schedule`](https://github.com/zslayton/cron/pull/129/commits/7520221e187c8a0473502c6d3ee367e1e14b6433)

This changeset improves upon #118 by making use of the recently merged https://github.com/zslayton/cron/pull/128:

### Serialization

Serialization uses a direct reference into the `Schedule::source`.

Previously, the blanket implementation of `ToString::to_string` had been used, which unnecessarily allocated a string and leveraged `format!` machinery.

### Deserialization

Deserialization suggests the `Deserializer` to provide an owned `String` to the visitor, as the `Schedule` will take ownership of the `String` after successful decoding.

`Deserializer`s not incapable of providing owned `String`s may pass a `&str`, which is decoded, then cloned into an owned `String` for storage in `Schedule::source`.

### Public API changes

Beside implementing `Serialize` and `Deserialize` behind the `"serde"` feature flag, this changeset also adds a new public method `Schedule::source(&self) -> &str`.

This new public method is generally useful and therefore not guarded by the `"serde"` feature flag.

## 3cb0fa310182ebe8b838995f14abe4a30992233f &mdash; [feat(ci): run tests for default features and all features separately](https://github.com/zslayton/cron/pull/129/commits/3cb0fa310182ebe8b838995f14abe4a30992233f)

The tests for `#[cfg(feature = "serde")]` had not been run in CI.

This change creates separate CI jobs for testing with default features and testing with all features, to spot incompatibilities, dead code and incorrect feature gates.

## 365409d7d93d1c85b527461633a273c5cadc81af &mdash; [style: normalize serde tests](https://github.com/zslayton/cron/pull/129/commits/365409d7d93d1c85b527461633a273c5cadc81af)

This stylistic change prepares for the upcoming addition of end-to-end deserialized schedule event iterator tests by renaming the existing `serde_test`-based tests by adding an idicator that only the token representation is tested.

The changeset also [lowercases][C-GOOD-ERR] failure messages, and renames variables to match crate conventions.

[C-GOOD-ERR]: https://rust-lang.github.io/api-guidelines/interoperability.html?highlight=lowercase#error-types-are-meaningful-and-well-behaved-c-good-err

## dede2c7c03ce27f4a49363510458b2d4c0c718f6 &mdash; [test: e2e-test deserialized schedules with binary format](https://github.com/zslayton/cron/pull/129/commits/dede2c7c03ce27f4a49363510458b2d4c0c718f6)

This changeset implements serde serialization and deserialization tests beyond the token representation tests provided by `serde_test`.

Schedules are serialized to a binary format, then deserialized and used to yield events following a given date and time. These events are compared to a limited set of restricted upcoming events.

The tests cover shorthand as well as ranged period cron schedule notation.

[Postcard][postcard] was chosen over `serde_json` and `serde_yml` as it is fast to compile, efficient to run, and because its serialization target format is not text based but binary. Default features are disabled.

[postcard]: https://docs.rs/postcard/

# Open questions

_**Solved:** end-to-end tests with (binary) storage format added in dede2c7c03ce27f4a49363510458b2d4c0c718f6._

<details>

In https://github.com/zslayton/cron/pull/118#pullrequestreview-2023579873 you had asked for some unit tests for patterns beyond `"* * * * * * *"`.

I wonder if this request still holds? _Decoding of patterns_ is unit-tested elsewhere.

The serialization and deserialization unit tests appear to me to be covered by a successful `serde_test::assert_tokens` and an intentionally failing `serde_test::assert_de_tokens_error`.~~

If you would like to see further patterns used in the serde tests regardless, then I would ask you to point me to specifics regarding which kinds of patterns you would like to see tested.  I would then push a fourth commit adding the requested tests.

</details>

