### PR TITLE
Fix backwards iteration when initial time has nanoseconds

### DIFF
--- a/src/queries.rs
+++ b/src/queries.rs
@@ -120,7 +120,7 @@ where
     Z: TimeZone,
 {
     pub fn from(before: &DateTime<Z>) -> PrevFromQuery<Z> {
-        let initial_datetime = if before.timestamp_subsec_millis() > 0 {
+        let initial_datetime = if before.timestamp_subsec_nanos() > 0 {
             before.clone()
         } else {
             before.clone() - Duration::seconds(1)

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -754,7 +754,7 @@ mod test {
         assert!(prev.single().is_some());
         assert_eq!(prev, next);
 
-        let prev2 = schedule.prev_from(&(next2.unwrap() + Duration::milliseconds(100)));
+        let prev2 = schedule.prev_from(&(next2.unwrap() + Duration::nanoseconds(100)));
         println!("PREV2 FROM for {} {:?}", expression, prev2);
         assert!(prev2.single().is_some());
         assert_eq!(prev2, next2);


### PR DESCRIPTION
#112 was really close but is still incorrect when the initial time has less than 1 ms, e.g. 500 nanoseconds.