### PR TITLE
chore: Add `cargo fmt` and `clippy` checks to GitHub action 

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,3 +24,7 @@ jobs:
       run: cargo test --verbose --all-features
     - name: Build docs
       run: cargo doc --no-deps --verbose
+    - name: Check formatting
+      run: cargo fmt -- --check
+    - name: Check linting
+      run: cargo clippy --all-targets --all-features -- -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Build
       run: cargo build --verbose
     - name: Run tests (default features)

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -436,7 +436,7 @@ where
     }
 }
 
-impl<'a, Z> Iterator for ScheduleIterator<'a, Z>
+impl<Z> Iterator for ScheduleIterator<'_, Z>
 where
     Z: TimeZone,
 {
@@ -465,7 +465,7 @@ where
     }
 }
 
-impl<'a, Z> DoubleEndedIterator for ScheduleIterator<'a, Z>
+impl<Z> DoubleEndedIterator for ScheduleIterator<'_, Z>
 where
     Z: TimeZone,
 {
@@ -603,7 +603,7 @@ fn days_in_month(month: Ordinal, year: Ordinal) -> u32 {
 struct ScheduleVisitor;
 
 #[cfg(feature = "serde")]
-impl<'de> Visitor<'de> for ScheduleVisitor {
+impl Visitor<'_> for ScheduleVisitor {
     type Value = Schedule;
 
     fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/time_unit/mod.rs
+++ b/src/time_unit/mod.rs
@@ -26,14 +26,14 @@ pub struct OrdinalIter<'a> {
     set_iter: btree_set::Iter<'a, Ordinal>,
 }
 
-impl<'a> Iterator for OrdinalIter<'a> {
+impl Iterator for OrdinalIter<'_> {
     type Item = Ordinal;
     fn next(&mut self) -> Option<Ordinal> {
         self.set_iter.next().copied()
     }
 }
 
-impl<'a> DoubleEndedIterator for OrdinalIter<'a> {
+impl DoubleEndedIterator for OrdinalIter<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.set_iter.next_back().copied()
     }
@@ -43,14 +43,14 @@ pub struct OrdinalRangeIter<'a> {
     range_iter: btree_set::Range<'a, Ordinal>,
 }
 
-impl<'a> Iterator for OrdinalRangeIter<'a> {
+impl Iterator for OrdinalRangeIter<'_> {
     type Item = Ordinal;
     fn next(&mut self) -> Option<Ordinal> {
         self.range_iter.next().copied()
     }
 }
 
-impl<'a> DoubleEndedIterator for OrdinalRangeIter<'a> {
+impl DoubleEndedIterator for OrdinalRangeIter<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.range_iter.next_back().copied()
     }


### PR DESCRIPTION
- chore: Add cargo fmt and clippy checks to GitHub action 
  Followup from #117 and partly #123 addressing these issues. This is now
  checked in the GitHub action pipeline to avoid adding new violations.
- chore: Update actions/checkout
-  Fix `clippy` issues
Remove lifetime annotations which can rely on lifetime elision.
---

I did not add any suggestions from https://github.com/zslayton/cron/pull/117#issuecomment-2444128976, it feels a bit too opinionated and didn't include any explanations or reasoning. Instead I opted to use the default settings for linting.