### PR TITLE
refactor(parser): Port to winnow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ name = "cron"
 
 [dependencies]
 chrono = { version = "~0.4", default-features = false, features = ["clock"] }
-nom = "~7"
+winnow = "0.6.20"
 once_cell = "1.10"
 serde = {version = "1.0.164", optional = true }
 

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -1,10 +1,7 @@
-use nom::branch::alt;
-use nom::bytes::complete::tag;
-use nom::character::complete::{alpha1, digit1, multispace0};
-use nom::combinator::{all_consuming, eof, map, map_res, opt};
-use nom::multi::separated_list1;
-use nom::sequence::{delimited, separated_pair, terminated, tuple};
-use nom::IResult;
+use winnow::ascii::{alpha1, digit1, multispace0};
+use winnow::combinator::{alt, delimited, eof, opt, separated, separated_pair, terminated};
+use winnow::prelude::*;
+use winnow::PResult;
 
 use std::borrow::Cow;
 use std::convert::TryFrom;
@@ -20,8 +17,8 @@ impl TryFrom<Cow<'_, str>> for Schedule {
     type Error = Error;
 
     fn try_from(expression: Cow<'_, str>) -> Result<Self, Self::Error> {
-        match schedule(&expression) {
-            Ok((_, schedule_fields)) => Ok(Schedule::new(expression.into_owned(), schedule_fields)), // Extract from nom tuple
+        match schedule.parse(&expression) {
+            Ok(schedule_fields) => Ok(Schedule::new(expression.into_owned(), schedule_fields)), // Extract from nom tuple
             Err(_) => Err(ErrorKind::Expression("Invalid cron expression.".to_owned()).into()), //TODO: Details
         }
     }
@@ -85,108 +82,103 @@ where
     }
 }
 
-fn ordinal(i: &str) -> IResult<&str, u32> {
-    map_res(delimited(multispace0, digit1, multispace0), u32::from_str)(i)
+fn ordinal(i: &mut &str) -> PResult<u32> {
+    delimited(multispace0, digit1, multispace0)
+        .try_map(u32::from_str)
+        .parse_next(i)
 }
 
-fn name(i: &str) -> IResult<&str, String> {
-    map(
-        delimited(multispace0, alpha1, multispace0),
-        ToOwned::to_owned,
-    )(i)
+fn name(i: &mut &str) -> PResult<String> {
+    delimited(multispace0, alpha1, multispace0)
+        .map(ToOwned::to_owned)
+        .parse_next(i)
 }
 
-fn point(i: &str) -> IResult<&str, Specifier> {
-    let (i, o) = ordinal(i)?;
-    Ok((i, Specifier::Point(o)))
+fn point(i: &mut &str) -> PResult<Specifier> {
+    ordinal.map(Specifier::Point).parse_next(i)
 }
 
-fn named_point(i: &str) -> IResult<&str, RootSpecifier> {
-    let (i, n) = name(i)?;
-    Ok((i, RootSpecifier::NamedPoint(n)))
+fn named_point(i: &mut &str) -> PResult<RootSpecifier> {
+    name.map(RootSpecifier::NamedPoint).parse_next(i)
 }
 
-fn period(i: &str) -> IResult<&str, RootSpecifier> {
-    map(
-        separated_pair(specifier, tag("/"), ordinal),
-        |(start, step)| RootSpecifier::Period(start, step),
-    )(i)
+fn period(i: &mut &str) -> PResult<RootSpecifier> {
+    separated_pair(specifier, "/", ordinal)
+        .map(|(start, step)| RootSpecifier::Period(start, step))
+        .parse_next(i)
 }
 
-fn period_with_any(i: &str) -> IResult<&str, RootSpecifier> {
-    map(
-        separated_pair(specifier_with_any, tag("/"), ordinal),
-        |(start, step)| RootSpecifier::Period(start, step),
-    )(i)
+fn period_with_any(i: &mut &str) -> PResult<RootSpecifier> {
+    separated_pair(specifier_with_any, "/", ordinal)
+        .map(|(start, step)| RootSpecifier::Period(start, step))
+        .parse_next(i)
 }
 
-fn range(i: &str) -> IResult<&str, Specifier> {
-    map(
-        separated_pair(ordinal, tag("-"), ordinal),
-        |(start, end)| Specifier::Range(start, end),
-    )(i)
+fn range(i: &mut &str) -> PResult<Specifier> {
+    separated_pair(ordinal, "-", ordinal)
+        .map(|(start, end)| Specifier::Range(start, end))
+        .parse_next(i)
 }
 
-fn named_range(i: &str) -> IResult<&str, Specifier> {
-    map(separated_pair(name, tag("-"), name), |(start, end)| {
-        Specifier::NamedRange(start, end)
-    })(i)
+fn named_range(i: &mut &str) -> PResult<Specifier> {
+    separated_pair(name, "-", name)
+        .map(|(start, end)| Specifier::NamedRange(start, end))
+        .parse_next(i)
 }
 
-fn all(i: &str) -> IResult<&str, Specifier> {
-    let (i, _) = tag("*")(i)?;
-    Ok((i, Specifier::All))
+fn all(i: &mut &str) -> PResult<Specifier> {
+    "*".map(|_| Specifier::All).parse_next(i)
 }
 
-fn any(i: &str) -> IResult<&str, Specifier> {
-    let (i, _) = tag("?")(i)?;
-    Ok((i, Specifier::All))
+fn any(i: &mut &str) -> PResult<Specifier> {
+    "?".map(|_| Specifier::All).parse_next(i)
 }
 
-fn specifier(i: &str) -> IResult<&str, Specifier> {
-    alt((all, range, point, named_range))(i)
+fn specifier(i: &mut &str) -> PResult<Specifier> {
+    alt((all, range, point, named_range)).parse_next(i)
 }
 
-fn specifier_with_any(i: &str) -> IResult<&str, Specifier> {
-    alt((any, specifier))(i)
+fn specifier_with_any(i: &mut &str) -> PResult<Specifier> {
+    alt((any, specifier)).parse_next(i)
 }
 
-fn root_specifier(i: &str) -> IResult<&str, RootSpecifier> {
-    alt((period, map(specifier, RootSpecifier::from), named_point))(i)
+fn root_specifier(i: &mut &str) -> PResult<RootSpecifier> {
+    alt((period, specifier.map(RootSpecifier::from), named_point)).parse_next(i)
 }
 
-fn root_specifier_with_any(i: &str) -> IResult<&str, RootSpecifier> {
+fn root_specifier_with_any(i: &mut &str) -> PResult<RootSpecifier> {
     alt((
         period_with_any,
-        map(specifier_with_any, RootSpecifier::from),
+        specifier_with_any.map(RootSpecifier::from),
         named_point,
-    ))(i)
+    ))
+    .parse_next(i)
 }
 
-fn root_specifier_list(i: &str) -> IResult<&str, Vec<RootSpecifier>> {
-    let list = separated_list1(tag(","), root_specifier);
-    let single_item = map(root_specifier, |spec| vec![spec]);
-    delimited(multispace0, alt((list, single_item)), multispace0)(i)
+fn root_specifier_list(i: &mut &str) -> PResult<Vec<RootSpecifier>> {
+    let list = separated(1.., root_specifier, ",");
+    let single_item = root_specifier.map(|spec| vec![spec]);
+    delimited(multispace0, alt((list, single_item)), multispace0).parse_next(i)
 }
 
-fn root_specifier_list_with_any(i: &str) -> IResult<&str, Vec<RootSpecifier>> {
-    let list = separated_list1(tag(","), root_specifier_with_any);
-    let single_item = map(root_specifier_with_any, |spec| vec![spec]);
-    delimited(multispace0, alt((list, single_item)), multispace0)(i)
+fn root_specifier_list_with_any(i: &mut &str) -> PResult<Vec<RootSpecifier>> {
+    let list = separated(1.., root_specifier_with_any, ",");
+    let single_item = root_specifier_with_any.map(|spec| vec![spec]);
+    delimited(multispace0, alt((list, single_item)), multispace0).parse_next(i)
 }
 
-fn field(i: &str) -> IResult<&str, Field> {
-    let (i, specifiers) = root_specifier_list(i)?;
-    Ok((i, Field { specifiers }))
+fn field(i: &mut &str) -> PResult<Field> {
+    let specifiers = root_specifier_list.parse_next(i)?;
+    Ok(Field { specifiers })
 }
 
-fn field_with_any(i: &str) -> IResult<&str, Field> {
-    let (i, specifiers) = root_specifier_list_with_any(i)?;
-    Ok((i, Field { specifiers }))
+fn field_with_any(i: &mut &str) -> PResult<Field> {
+    let specifiers = root_specifier_list_with_any.parse_next(i)?;
+    Ok(Field { specifiers })
 }
 
-fn shorthand_yearly(i: &str) -> IResult<&str, ScheduleFields> {
-    let (i, _) = tag("@yearly")(i)?;
+fn shorthand_yearly(i: &mut &str) -> PResult<ScheduleFields> {
+    "@yearly".parse_next(i)?;
     let fields = ScheduleFields::new(
         Seconds::from_ordinal(0),
         Minutes::from_ordinal(0),
@@ -196,11 +188,11 @@ fn shorthand_yearly(i: &str) -> IResult<&str, ScheduleFields> {
         DaysOfWeek::all(),
         Years::all(),
     );
-    Ok((i, fields))
+    Ok(fields)
 }
 
-fn shorthand_monthly(i: &str) -> IResult<&str, ScheduleFields> {
-    let (i, _) = tag("@monthly")(i)?;
+fn shorthand_monthly(i: &mut &str) -> PResult<ScheduleFields> {
+    "@monthly".parse_next(i)?;
     let fields = ScheduleFields::new(
         Seconds::from_ordinal(0),
         Minutes::from_ordinal(0),
@@ -210,11 +202,11 @@ fn shorthand_monthly(i: &str) -> IResult<&str, ScheduleFields> {
         DaysOfWeek::all(),
         Years::all(),
     );
-    Ok((i, fields))
+    Ok(fields)
 }
 
-fn shorthand_weekly(i: &str) -> IResult<&str, ScheduleFields> {
-    let (i, _) = tag("@weekly")(i)?;
+fn shorthand_weekly(i: &mut &str) -> PResult<ScheduleFields> {
+    "@weekly".parse_next(i)?;
     let fields = ScheduleFields::new(
         Seconds::from_ordinal(0),
         Minutes::from_ordinal(0),
@@ -224,11 +216,11 @@ fn shorthand_weekly(i: &str) -> IResult<&str, ScheduleFields> {
         DaysOfWeek::from_ordinal(1),
         Years::all(),
     );
-    Ok((i, fields))
+    Ok(fields)
 }
 
-fn shorthand_daily(i: &str) -> IResult<&str, ScheduleFields> {
-    let (i, _) = tag("@daily")(i)?;
+fn shorthand_daily(i: &mut &str) -> PResult<ScheduleFields> {
+    "@daily".parse_next(i)?;
     let fields = ScheduleFields::new(
         Seconds::from_ordinal(0),
         Minutes::from_ordinal(0),
@@ -238,11 +230,11 @@ fn shorthand_daily(i: &str) -> IResult<&str, ScheduleFields> {
         DaysOfWeek::all(),
         Years::all(),
     );
-    Ok((i, fields))
+    Ok(fields)
 }
 
-fn shorthand_hourly(i: &str) -> IResult<&str, ScheduleFields> {
-    let (i, _) = tag("@hourly")(i)?;
+fn shorthand_hourly(i: &mut &str) -> PResult<ScheduleFields> {
+    "@hourly".parse_next(i)?;
     let fields = ScheduleFields::new(
         Seconds::from_ordinal(0),
         Minutes::from_ordinal(0),
@@ -252,10 +244,10 @@ fn shorthand_hourly(i: &str) -> IResult<&str, ScheduleFields> {
         DaysOfWeek::all(),
         Years::all(),
     );
-    Ok((i, fields))
+    Ok(fields)
 }
 
-fn shorthand(i: &str) -> IResult<&str, ScheduleFields> {
+fn shorthand(i: &mut &str) -> PResult<ScheduleFields> {
     let keywords = alt((
         shorthand_yearly,
         shorthand_monthly,
@@ -263,18 +255,18 @@ fn shorthand(i: &str) -> IResult<&str, ScheduleFields> {
         shorthand_daily,
         shorthand_hourly,
     ));
-    delimited(multispace0, keywords, multispace0)(i)
+    delimited(multispace0, keywords, multispace0).parse_next(i)
 }
 
-fn longhand(i: &str) -> IResult<&str, ScheduleFields> {
-    let seconds = map_res(field, Seconds::from_field);
-    let minutes = map_res(field, Minutes::from_field);
-    let hours = map_res(field, Hours::from_field);
-    let days_of_month = map_res(field_with_any, DaysOfMonth::from_field);
-    let months = map_res(field, Months::from_field);
-    let days_of_week = map_res(field_with_any, DaysOfWeek::from_field);
-    let years = opt(map_res(field, Years::from_field));
-    let fields = tuple((
+fn longhand(i: &mut &str) -> PResult<ScheduleFields> {
+    let seconds = field.try_map(Seconds::from_field);
+    let minutes = field.try_map(Minutes::from_field);
+    let hours = field.try_map(Hours::from_field);
+    let days_of_month = field_with_any.try_map(DaysOfMonth::from_field);
+    let months = field.try_map(Months::from_field);
+    let days_of_week = field_with_any.try_map(DaysOfWeek::from_field);
+    let years = opt(field.try_map(Years::from_field));
+    let fields = (
         seconds,
         minutes,
         hours,
@@ -282,27 +274,28 @@ fn longhand(i: &str) -> IResult<&str, ScheduleFields> {
         months,
         days_of_week,
         years,
-    ));
+    );
 
-    map(
-        terminated(fields, eof),
-        |(seconds, minutes, hours, days_of_month, months, days_of_week, years)| {
-            let years = years.unwrap_or_else(Years::all);
-            ScheduleFields::new(
-                seconds,
-                minutes,
-                hours,
-                days_of_month,
-                months,
-                days_of_week,
-                years,
-            )
-        },
-    )(i)
+    terminated(fields, eof)
+        .map(
+            |(seconds, minutes, hours, days_of_month, months, days_of_week, years)| {
+                let years = years.unwrap_or_else(Years::all);
+                ScheduleFields::new(
+                    seconds,
+                    minutes,
+                    hours,
+                    days_of_month,
+                    months,
+                    days_of_week,
+                    years,
+                )
+            },
+        )
+        .parse_next(i)
 }
 
-fn schedule(i: &str) -> IResult<&str, ScheduleFields> {
-    all_consuming(alt((shorthand, longhand)))(i)
+fn schedule(i: &mut &str) -> PResult<ScheduleFields> {
+    alt((shorthand, longhand)).parse_next(i)
 }
 
 #[cfg(test)]
@@ -312,324 +305,324 @@ mod test {
     #[test]
     fn test_nom_valid_number() {
         let expression = "1997";
-        point(expression).unwrap();
+        point.parse(expression).unwrap();
     }
 
     #[test]
     fn test_nom_invalid_point() {
         let expression = "a";
-        assert!(point(expression).is_err());
+        assert!(point.parse(expression).is_err());
     }
 
     #[test]
     fn test_nom_valid_named_point() {
         let expression = "WED";
-        named_point(expression).unwrap();
+        named_point.parse(expression).unwrap();
     }
 
     #[test]
     fn test_nom_invalid_named_point() {
         let expression = "8";
-        assert!(named_point(expression).is_err());
+        assert!(named_point.parse(expression).is_err());
     }
 
     #[test]
     fn test_nom_valid_period() {
         let expression = "1/2";
-        period(expression).unwrap();
+        period.parse(expression).unwrap();
     }
 
     #[test]
     fn test_nom_invalid_period() {
         let expression = "Wed/4";
-        assert!(period(expression).is_err());
+        assert!(period.parse(expression).is_err());
     }
 
     #[test]
     fn test_nom_valid_number_list() {
         let expression = "1,2";
-        field(expression).unwrap();
-        field_with_any(expression).unwrap();
+        field.parse(expression).unwrap();
+        field_with_any.parse(expression).unwrap();
     }
 
     #[test]
     fn test_nom_invalid_number_list() {
         let expression = ",1,2";
-        assert!(field(expression).is_err());
-        assert!(field_with_any(expression).is_err());
+        assert!(field.parse(expression).is_err());
+        assert!(field_with_any.parse(expression).is_err());
     }
 
     #[test]
     fn test_nom_field_with_any_valid_any() {
         let expression = "?";
-        field_with_any(expression).unwrap();
+        field_with_any.parse(expression).unwrap();
     }
 
     #[test]
     fn test_nom_field_invalid_any() {
         let expression = "?";
-        assert!(field(expression).is_err());
+        assert!(field.parse(expression).is_err());
     }
 
     #[test]
     fn test_nom_valid_range_field() {
         let expression = "1-4";
-        range(expression).unwrap();
+        range.parse(expression).unwrap();
     }
 
     #[test]
     fn test_nom_valid_period_all() {
         let expression = "*/2";
-        period(expression).unwrap();
+        period.parse(expression).unwrap();
     }
 
     #[test]
     fn test_nom_valid_period_range() {
         let expression = "10-20/2";
-        period(expression).unwrap();
+        period.parse(expression).unwrap();
     }
 
     #[test]
     fn test_nom_valid_period_named_range() {
         let expression = "Mon-Thurs/2";
-        period(expression).unwrap();
+        period.parse(expression).unwrap();
 
         let expression = "February-November/2";
-        period(expression).unwrap();
+        period.parse(expression).unwrap();
     }
 
     #[test]
     fn test_nom_valid_period_point() {
         let expression = "10/2";
-        period(expression).unwrap();
+        period.parse(expression).unwrap();
     }
 
     #[test]
     fn test_nom_invalid_period_any() {
         let expression = "?/2";
-        assert!(period(expression).is_err());
+        assert!(period.parse(expression).is_err());
     }
 
     #[test]
     fn test_nom_invalid_period_named_point() {
         let expression = "Tues/2";
-        assert!(period(expression).is_err());
+        assert!(period.parse(expression).is_err());
 
         let expression = "February/2";
-        assert!(period(expression).is_err());
+        assert!(period.parse(expression).is_err());
     }
 
     #[test]
     fn test_nom_invalid_period_specifier_range() {
         let expression = "10-12/*";
-        assert!(period(expression).is_err());
+        assert!(period.parse(expression).is_err());
     }
 
     #[test]
     fn test_nom_valid_period_with_any_all() {
         let expression = "*/2";
-        period_with_any(expression).unwrap();
+        period_with_any.parse(expression).unwrap();
     }
 
     #[test]
     fn test_nom_valid_period_with_any_range() {
         let expression = "10-20/2";
-        period_with_any(expression).unwrap();
+        period_with_any.parse(expression).unwrap();
     }
 
     #[test]
     fn test_nom_valid_period_with_any_named_range() {
         let expression = "Mon-Thurs/2";
-        period_with_any(expression).unwrap();
+        period_with_any.parse(expression).unwrap();
 
         let expression = "February-November/2";
-        period_with_any(expression).unwrap();
+        period_with_any.parse(expression).unwrap();
     }
 
     #[test]
     fn test_nom_valid_period_with_any_point() {
         let expression = "10/2";
-        period_with_any(expression).unwrap();
+        period_with_any.parse(expression).unwrap();
     }
 
     #[test]
     fn test_nom_valid_period_with_any_any() {
         let expression = "?/2";
-        period_with_any(expression).unwrap();
+        period_with_any.parse(expression).unwrap();
     }
 
     #[test]
     fn test_nom_invalid_period_with_any_named_point() {
         let expression = "Tues/2";
-        assert!(period_with_any(expression).is_err());
+        assert!(period_with_any.parse(expression).is_err());
 
         let expression = "February/2";
-        assert!(period_with_any(expression).is_err());
+        assert!(period_with_any.parse(expression).is_err());
     }
 
     #[test]
     fn test_nom_invalid_period_with_any_specifier_range() {
         let expression = "10-12/*";
-        assert!(period_with_any(expression).is_err());
+        assert!(period_with_any.parse(expression).is_err());
     }
 
     #[test]
     fn test_nom_invalid_range_field() {
         let expression = "-4";
-        assert!(range(expression).is_err());
+        assert!(range.parse(expression).is_err());
     }
 
     #[test]
     fn test_nom_valid_named_range_field() {
         let expression = "TUES-THURS";
-        named_range(expression).unwrap();
+        named_range.parse(expression).unwrap();
     }
 
     #[test]
     fn test_nom_invalid_named_range_field() {
         let expression = "3-THURS";
-        assert!(named_range(expression).is_err());
+        assert!(named_range.parse(expression).is_err());
     }
 
     #[test]
     fn test_nom_valid_schedule() {
         let expression = "* * * * * *";
-        schedule(expression).unwrap();
+        schedule.parse(expression).unwrap();
     }
 
     #[test]
     fn test_nom_invalid_schedule() {
         let expression = "* * * *";
-        assert!(schedule(expression).is_err());
+        assert!(schedule.parse(expression).is_err());
     }
 
     #[test]
     fn test_nom_valid_seconds_list() {
         let expression = "0,20,40 * * * * *";
-        schedule(expression).unwrap();
+        schedule.parse(expression).unwrap();
     }
 
     #[test]
     fn test_nom_valid_seconds_range() {
         let expression = "0-40 * * * * *";
-        schedule(expression).unwrap();
+        schedule.parse(expression).unwrap();
     }
 
     #[test]
     fn test_nom_valid_seconds_mix() {
         let expression = "0-5,58 * * * * *";
-        schedule(expression).unwrap();
+        schedule.parse(expression).unwrap();
     }
 
     #[test]
     fn test_nom_invalid_seconds_range() {
         let expression = "0-65 * * * * *";
-        assert!(schedule(expression).is_err());
+        assert!(schedule.parse(expression).is_err());
     }
 
     #[test]
     fn test_nom_invalid_seconds_list() {
         let expression = "103,12 * * * * *";
-        assert!(schedule(expression).is_err());
+        assert!(schedule.parse(expression).is_err());
     }
 
     #[test]
     fn test_nom_invalid_seconds_mix() {
         let expression = "0-5,102 * * * * *";
-        assert!(schedule(expression).is_err());
+        assert!(schedule.parse(expression).is_err());
     }
 
     #[test]
     fn test_nom_valid_days_of_week_list() {
         let expression = "* * * * * MON,WED,FRI";
-        schedule(expression).unwrap();
+        schedule.parse(expression).unwrap();
     }
 
     #[test]
     fn test_nom_invalid_days_of_week_list() {
         let expression = "* * * * * MON,TURTLE";
-        assert!(schedule(expression).is_err());
+        assert!(schedule.parse(expression).is_err());
     }
 
     #[test]
     fn test_nom_valid_days_of_week_range() {
         let expression = "* * * * * MON-FRI";
-        schedule(expression).unwrap();
+        schedule.parse(expression).unwrap();
     }
 
     #[test]
     fn test_nom_invalid_days_of_week_range() {
         let expression = "* * * * * BEAR-OWL";
-        assert!(schedule(expression).is_err());
+        assert!(schedule.parse(expression).is_err());
     }
 
     #[test]
     fn test_nom_invalid_period_with_range_specifier() {
         let expression = "10-12/10-12 * * * * ?";
-        assert!(schedule(expression).is_err());
+        assert!(schedule.parse(expression).is_err());
     }
 
     #[test]
     fn test_nom_valid_days_of_month_any() {
         let expression = "* * * ? * *";
-        schedule(expression).unwrap();
+        schedule.parse(expression).unwrap();
     }
 
     #[test]
     fn test_nom_valid_days_of_week_any() {
         let expression = "* * * * * ?";
-        schedule(expression).unwrap();
+        schedule.parse(expression).unwrap();
     }
 
     #[test]
     fn test_nom_valid_days_of_month_any_days_of_week_specific() {
         let expression = "* * * ? * Mon,Thu";
-        schedule(expression).unwrap();
+        schedule.parse(expression).unwrap();
     }
 
     #[test]
     fn test_nom_valid_days_of_week_any_days_of_month_specific() {
         let expression = "* * * 1,2 * ?";
-        schedule(expression).unwrap();
+        schedule.parse(expression).unwrap();
     }
 
     #[test]
     fn test_nom_valid_dom_and_dow_any() {
         let expression = "* * * ? * ?";
-        schedule(expression).unwrap();
+        schedule.parse(expression).unwrap();
     }
 
     #[test]
     fn test_nom_invalid_other_fields_any() {
         let expression = "? * * * * *";
-        assert!(schedule(expression).is_err());
+        assert!(schedule.parse(expression).is_err());
 
         let expression = "* ? * * * *";
-        assert!(schedule(expression).is_err());
+        assert!(schedule.parse(expression).is_err());
 
         let expression = "* * ? * * *";
-        assert!(schedule(expression).is_err());
+        assert!(schedule.parse(expression).is_err());
 
         let expression = "* * * * ? *";
-        assert!(schedule(expression).is_err());
+        assert!(schedule.parse(expression).is_err());
     }
 
     #[test]
     fn test_nom_invalid_trailing_characters() {
         let expression = "* * * * * *foo *";
-        assert!(schedule(expression).is_err());
+        assert!(schedule.parse(expression).is_err());
 
         let expression = "* * * * * * * foo";
-        assert!(schedule(expression).is_err());
+        assert!(schedule.parse(expression).is_err());
     }
 
     /// Issue #86
     #[test]
     fn shorthand_must_match_whole_input() {
         let expression = "@dailyBla";
-        assert!(schedule(expression).is_err());
+        assert!(schedule.parse(expression).is_err());
         let expression = " @dailyBla ";
-        assert!(schedule(expression).is_err());
+        assert!(schedule.parse(expression).is_err());
     }
 
     #[test]
@@ -675,7 +668,7 @@ mod test {
             "1,2,3/60 * * * * *",
             "0 0 0 1 1 ? 2020-2040/2200",
         ] {
-            assert!(schedule(invalid_expression).is_err());
+            assert!(schedule.parse(invalid_expression).is_err());
         }
 
         for valid_expression in [
@@ -688,7 +681,7 @@ mod test {
             "1,2,3/5 * * * * *",
             "0 0 0 1 1 ? 2020-2040/10",
         ] {
-            assert!(schedule(valid_expression).is_ok());
+            assert!(schedule.parse(valid_expression).is_ok());
         }
     }
 }


### PR DESCRIPTION
I want to be clear, just because I did this, there is no pressure to adopt it.  I did this more out of procrastination than anything.

In case you aren't aware, winnow was forked from nom 2 years ago with a focus on ease of use (simpler, clearer API, more documentation, etc), batteries included (nom-located, nom-trace, etc are built-in), and maintainable.  Its in use by `toml` and many other crates which means there is a chance people are already depending on it.

From this PR, it would be relatively easy to
- Improve the performance by using parsers like [`dispatch!` over `alt`](https://docs.rs/winnow/latest/winnow/_tutorial/chapter_3/index.html#alternatives)
- Provide context-aware error messages thanks to [the default error type, `cut_err`](https://docs.rs/winnow/latest/winnow/_tutorial/chapter_7/index.html), and [`Parser::parse`](https://docs.rs/winnow/latest/winnow/_tutorial/chapter_6/index.html)
- Add [`trace`](https://docs.rs/winnow/latest/winnow/_tutorial/chapter_8/index.html) parsers for easier debugging