### PR TITLE
feat(parsing): give serviceable parsing error details to users

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -16,7 +16,7 @@ pub enum ErrorKind {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.kind {
-            ErrorKind::Expression(ref expr) => write!(f, "Invalid expression: {}", expr),
+            ErrorKind::Expression(ref expr) => write!(f, "{expr}"),
         }
     }
 }

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -18,8 +18,8 @@ impl TryFrom<Cow<'_, str>> for Schedule {
 
     fn try_from(expression: Cow<'_, str>) -> Result<Self, Self::Error> {
         match schedule.parse(&expression) {
-            Ok(schedule_fields) => Ok(Schedule::new(expression.into_owned(), schedule_fields)), // Extract from nom tuple
-            Err(_) => Err(ErrorKind::Expression("Invalid cron expression.".to_owned()).into()), //TODO: Details
+            Ok(schedule_fields) => Ok(Schedule::new(expression.into_owned(), schedule_fields)), // Extract from winnow tuple
+            Err(parse_error) => Err(ErrorKind::Expression(format!("{parse_error}")).into()),
         }
     }
 }

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -689,7 +689,9 @@ mod test {
             &[Token::String(
                 "definitively an invalid value for a cron schedule!",
             )],
-            "Invalid expression: Invalid cron expression.",
+            "definitively an invalid value for a cron schedule!\n\
+                ^\n\
+                The 'Seconds' field does not support using names. 'definitively' specified.",
         );
     }
 


### PR DESCRIPTION
PR #134 was, in my opinion, a missed opportunity to improve the diagnostics offered by `cron::error::Error` to users, which at the moment always displays as an unhelpful "Invalid expression: Invalid cron expression." string. Let's improve on that by displaying the underlying parse error instead, which is serviceable enough to know what the input was and what exactly went wrong parsing it.