### PR TITLE
Add "vixie" feature that changes the implementation to be vixie-compatible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ chrono = { version = "~0.4", default-features = false, features = ["clock"] }
 winnow = "0.6.20"
 once_cell = "1.10"
 serde = {version = "1.0.164", optional = true }
+phf = { version = "0.13.1", features = ["macros"] }
 
 [dev-dependencies]
 chrono-tz = "~0.6"
@@ -30,3 +31,4 @@ postcard = { version = "1.0.10", default-features = false, features = ["use-std"
 
 [features]
 serde = ["dep:serde"]
+vixie = []

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -205,6 +205,22 @@ fn shorthand_monthly(i: &mut &str) -> PResult<ScheduleFields> {
     Ok(fields)
 }
 
+#[cfg(feature = "vixie")]
+fn shorthand_weekly(i: &mut &str) -> PResult<ScheduleFields> {
+    "@weekly".parse_next(i)?;
+    let fields = ScheduleFields::new(
+        Seconds::from_ordinal(0),
+        Minutes::from_ordinal(0),
+        Hours::from_ordinal(0),
+        DaysOfMonth::all(),
+        Months::all(),
+        DaysOfWeek::from_ordinal(0),
+        Years::all(),
+    );
+    Ok(fields)
+}
+
+#[cfg(not(feature = "vixie"))]
 fn shorthand_weekly(i: &mut &str) -> PResult<ScheduleFields> {
     "@weekly".parse_next(i)?;
     let fields = ScheduleFields::new(

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -37,7 +37,8 @@ impl Schedule {
         Z: TimeZone,
     {
         #[cfg(feature = "vixie")]
-        let dow_and_dom_specific = !self.fields.days_of_week.is_all() && !self.fields.days_of_month.is_all();
+        let dow_and_dom_specific =
+            !self.fields.days_of_week.is_all() && !self.fields.days_of_month.is_all();
 
         let mut query = NextAfterQuery::from(after);
         for year in self
@@ -64,36 +65,39 @@ impl Schedule {
                     Included(day_of_month_start.min(day_of_month_end)),
                     Included(day_of_month_end),
                 );
-                
+
                 #[cfg(not(feature = "vixie"))]
-                let day_of_month_candidates = {
-                  if !self.fields.days_of_month.ordinals().contains(&day_of_month_start) {
-                      query.reset_day_of_month();
-                  }
-                  days_of_month
-                      .range(day_of_month_range)
-                      .cloned()
-                      .filter(|dom| self.fields.days_of_week.ordinals().contains(&day_of_week(year, month, *dom)))
-                };
+                let mut day_of_month_candidates = days_of_month
+                    .range(day_of_month_range)
+                    .cloned()
+                    .filter(|dom| {
+                        self.fields
+                            .days_of_week
+                            .ordinals()
+                            .contains(&day_of_week(year, month, *dom))
+                    })
+                    .peekable();
 
                 #[cfg(feature = "vixie")]
-                let day_of_month_candidates = {
-                  if !dow_and_dom_specific && !days_of_month.contains(&day_of_month_start) {
-                      query.reset_day_of_month();
-                  }
-                      
-                  if dow_and_dom_specific {
-                      (day_of_month_start..=day_of_month_end)
+                let mut day_of_month_candidates = {
+                    let days_of_week = self.fields.days_of_week.ordinals();
+                    
+                    (day_of_month_start..=day_of_month_end)
                         .into_iter()
-                        .filter(|dom| self.fields.days_of_month.ordinals().contains(dom) 
-                            || self.fields.days_of_week.ordinals().contains(&day_of_week(year, month, *dom)))
-                  } else {
-                      days_of_month
-                        .range(day_of_month_range)
-                        .cloned()
-                        .filter(|dom| self.fields.days_of_week.ordinals().contains(&day_of_week(year, month, *dom)))
-                  }
+                        .filter(|dom| {
+                            if dow_and_dom_specific {
+                                return days_of_month.contains(dom)
+                                    || days_of_week.contains(&day_of_week(year, month, *dom));
+                            }
+                            days_of_month.contains(dom)
+                                && days_of_week.contains(&day_of_week(year, month, *dom))
+                        })
+                        .peekable()
                 };
+
+                if day_of_month_candidates.peek() != Some(&day_of_month_start) {
+                    query.reset_day_of_month();
+                }
 
                 for day_of_month in day_of_month_candidates {
                     let hour_start = query.hour_lower_bound();
@@ -132,7 +136,7 @@ impl Schedule {
                                 ) {
                                     LocalResult::None => continue,
                                     candidate => candidate,
-                                  };
+                                };
                             }
                             query.reset_minute();
                         } // End of minutes range
@@ -153,7 +157,8 @@ impl Schedule {
         Z: TimeZone,
     {
         #[cfg(feature = "vixie")]
-        let dow_and_dom_specific = !self.fields.days_of_week.is_all() && !self.fields.days_of_month.is_all();
+        let dow_and_dom_specific =
+            !self.fields.days_of_week.is_all() && !self.fields.days_of_month.is_all();
 
         let mut query = PrevFromQuery::from(before);
         for year in self
@@ -185,40 +190,42 @@ impl Schedule {
                     Included(DaysOfMonth::inclusive_min()),
                     Included(days_in_month(month, year).min(day_of_month_end)),
                 );
-                
-                #[cfg(not(feature = "vixie"))]
-                let day_of_month_candidates = {
-                  if !days_of_month.contains(&day_of_month_end) {
-                      query.reset_day_of_month();
-                  }
 
-                  days_of_month
+                #[cfg(not(feature = "vixie"))]
+                let mut day_of_month_candidates = days_of_month
                     .range(day_of_month_range)
                     .rev()
                     .cloned()
-                    .filter(|dom| self.fields.days_of_week.ordinals().contains(&day_of_week(year, month, *dom)))
-                };
+                    .filter(|dom| {
+                        self.fields
+                            .days_of_week
+                            .ordinals()
+                            .contains(&day_of_week(year, month, *dom))
+                    })
+                    .peekable();
 
                 #[cfg(feature = "vixie")]
-                let day_of_month_candidates = {
-                  if !dow_and_dom_specific && !days_of_month.contains(&day_of_month_end) {
-                      query.reset_day_of_month();
-                  }
-                      
-                  if dow_and_dom_specific {
-                      (day_of_month_end..=day_of_month_start)
+                let mut day_of_month_candidates = {
+                    let days_of_week = self.fields.days_of_week.ordinals();
+
+                    (DaysOfMonth::inclusive_min()..=day_of_month_end)
                         .into_iter()
-                        .filter(|dom| self.fields.days_of_month.ordinals().contains(dom) 
-                            || self.fields.days_of_week.ordinals().contains(&day_of_week(year, month, *dom)))
-                  } else {
-                      days_of_month
-                        .range(day_of_month_range)
                         .rev()
                         .cloned()
-                        .map(|dom| day_of_week(year, month, dom))
-                        .filter(|dom| self.fields.days_of_week.ordinals().contains(&day_of_week(year, month, *dom)))
-                  }
+                        .filter(|dom| {
+                            if dow_and_dom_specific {
+                                return days_of_month.contains(dom)
+                                    || days_of_week.contains(&day_of_week(year, month, *dom));
+                            }
+                            days_of_month.contains(dom)
+                                && days_of_week.contains(&day_of_week(year, month, *dom))
+                        })
+                        .peekable()
                 };
+
+                if day_of_month_candidates.peek() != Some(&day_of_month_end) {
+                    query.reset_day_of_month();
+                }
 
                 for day_of_month in day_of_month_candidates {
                     let hour_start = query.hour_upper_bound();
@@ -323,28 +330,39 @@ impl Schedule {
     /// Vixie cron behavior: If DOM is specific and DOW is inspecific, then only DOM is considered.
     /// If DOW is specific and DOM is inspecific, then only DOW is considered
     /// If both are specific, then either is considered.
-    fn includes_dom_dow<Z>(&self, date_time: &DateTime<Z>) -> bool 
-    where  
+    fn includes_dom_dow<Z>(&self, date_time: &DateTime<Z>) -> bool
+    where
         Z: TimeZone,
     {
         let dow_inspecific = self.fields.days_of_week.is_all();
         let dom_inspecific = self.fields.days_of_month.is_all();
-        let dow_includes = self.fields.days_of_week.includes(date_time.weekday().number_from_sunday());
-        let dom_includes = self.fields.days_of_month.includes(date_time.day() as Ordinal);
+        let dow_includes = self
+            .fields
+            .days_of_week
+            .includes(date_time.weekday().number_from_sunday());
+        let dom_includes = self
+            .fields
+            .days_of_month
+            .includes(date_time.day() as Ordinal);
 
-        (dow_inspecific || dom_inspecific) 
-            && (!dow_inspecific || dow_includes) 
+        (dow_inspecific || dom_inspecific)
+            && (!dow_inspecific || dow_includes)
             && (!dom_inspecific || dom_includes)
     }
 
     #[cfg(not(feature = "vixie"))]
     /// Quartz (the default) cron behavior: Both DOM and DOW must match.
-    fn includes_dom_dow<Z>(&self, date_time: &DateTime<Z>) -> bool 
-    where  
+    fn includes_dom_dow<Z>(&self, date_time: &DateTime<Z>) -> bool
+    where
         Z: TimeZone,
     {
-        self.fields.days_of_week.includes(date_time.weekday().number_from_sunday())
-            && self.fields.days_of_month.includes(date_time.day() as Ordinal)
+        self.fields
+            .days_of_week
+            .includes(date_time.weekday().number_from_sunday())
+            && self
+                .fields
+                .days_of_month
+                .includes(date_time.day() as Ordinal)
     }
 
     pub fn includes<Z>(&self, date_time: DateTime<Z>) -> bool
@@ -720,12 +738,8 @@ impl<'de> Deserialize<'de> for Schedule {
 
 #[cfg(test)]
 mod test {
-    use chrono::Duration;
     #[cfg(feature = "serde")]
     use serde_test::{assert_tokens, Token};
-
-    use super::*;
-    use std::str::FromStr;
 
     #[cfg(feature = "serde")]
     #[test]
@@ -790,272 +804,5 @@ mod test {
         ]
         .into_iter()
         .eq(schedule.after(&starting_date).take(7)));
-    }
-
-    #[test]
-    fn test_next_and_prev_from() {
-        let expression = "0 5,13,40-42 17 1 Jan *";
-        let schedule = Schedule::from_str(expression).unwrap();
-
-        let next = schedule.next_after(&Utc::now());
-        println!("NEXT AFTER for {} {:?}", expression, next);
-        assert!(next.single().is_some());
-
-        let next2 = schedule.next_after(&next.unwrap());
-        println!("NEXT2 AFTER for {} {:?}", expression, next2);
-        assert!(next2.single().is_some());
-
-        let prev = schedule.prev_from(&next2.unwrap());
-        println!("PREV FROM for {} {:?}", expression, prev);
-        assert!(prev.single().is_some());
-        assert_eq!(prev, next);
-
-        let prev2 = schedule.prev_from(&(next2.unwrap() + Duration::nanoseconds(100)));
-        println!("PREV2 FROM for {} {:?}", expression, prev2);
-        assert!(prev2.single().is_some());
-        assert_eq!(prev2, next2);
-    }
-
-    #[test]
-    fn test_next_after_past_date_next_year() {
-        // Schedule after 2021-10-27
-        let starting_point = Utc.with_ymd_and_hms(2021, 10, 27, 0, 0, 0).unwrap();
-
-        // Triggers on 2022-06-01. Note that the month and day are smaller than
-        // the month and day in `starting_point`.
-        let expression = "0 5 17 1 6 ? 2022".to_string();
-        let schedule = Schedule::from_str(&expression).unwrap();
-        let next = schedule.next_after(&starting_point);
-        println!("NEXT AFTER for {} {:?}", expression, next);
-        assert!(next.single().is_some());
-    }
-
-    #[test]
-    fn test_prev_from() {
-        let expression = "0 5,13,40-42 17 1 Jan *";
-        let schedule = Schedule::from_str(expression).unwrap();
-        let prev = schedule.prev_from(&Utc::now());
-        println!("PREV FROM for {} {:?}", expression, prev);
-        assert!(prev.single().is_some());
-    }
-
-    #[test]
-    fn test_next_after() {
-        let expression = "0 5,13,40-42 17 1 Jan *";
-        let schedule = Schedule::from_str(expression).unwrap();
-        let next = schedule.next_after(&Utc::now());
-        println!("NEXT AFTER for {} {:?}", expression, next);
-        assert!(next.single().is_some());
-    }
-
-    #[test]
-    fn test_upcoming_utc() {
-        let expression = "0 0,30 0,6,12,18 1,15 Jan-March Thurs";
-        let schedule = Schedule::from_str(expression).unwrap();
-        let mut upcoming = schedule.upcoming(Utc);
-        let next1 = upcoming.next();
-        assert!(next1.is_some());
-        let next2 = upcoming.next();
-        assert!(next2.is_some());
-        let next3 = upcoming.next();
-        assert!(next3.is_some());
-        println!("Upcoming 1 for {} {:?}", expression, next1);
-        println!("Upcoming 2 for {} {:?}", expression, next2);
-        println!("Upcoming 3 for {} {:?}", expression, next3);
-    }
-
-    #[test]
-    fn test_upcoming_utc_owned() {
-        let expression = "0 0,30 0,6,12,18 1,15 Jan-March Thurs";
-        let schedule = Schedule::from_str(expression).unwrap();
-        let mut upcoming = schedule.upcoming_owned(Utc);
-        let next1 = upcoming.next();
-        assert!(next1.is_some());
-        let next2 = upcoming.next();
-        assert!(next2.is_some());
-        let next3 = upcoming.next();
-        assert!(next3.is_some());
-        println!("Upcoming 1 for {} {:?}", expression, next1);
-        println!("Upcoming 2 for {} {:?}", expression, next2);
-        println!("Upcoming 3 for {} {:?}", expression, next3);
-    }
-
-    #[test]
-    fn test_upcoming_rev_utc() {
-        let expression = "0 0,30 0,6,12,18 1,15 Jan-March Thurs";
-        let schedule = Schedule::from_str(expression).unwrap();
-        let mut upcoming = schedule.upcoming(Utc).rev();
-        let prev1 = upcoming.next();
-        assert!(prev1.is_some());
-        let prev2 = upcoming.next();
-        assert!(prev2.is_some());
-        let prev3 = upcoming.next();
-        assert!(prev3.is_some());
-        println!("Prev Upcoming 1 for {} {:?}", expression, prev1);
-        println!("Prev Upcoming 2 for {} {:?}", expression, prev2);
-        println!("Prev Upcoming 3 for {} {:?}", expression, prev3);
-    }
-
-    #[test]
-    fn test_upcoming_rev_utc_owned() {
-        let expression = "0 0,30 0,6,12,18 1,15 Jan-March Thurs";
-        let schedule = Schedule::from_str(expression).unwrap();
-        let mut upcoming = schedule.upcoming_owned(Utc).rev();
-        let prev1 = upcoming.next();
-        assert!(prev1.is_some());
-        let prev2 = upcoming.next();
-        assert!(prev2.is_some());
-        let prev3 = upcoming.next();
-        assert!(prev3.is_some());
-        println!("Prev Upcoming 1 for {} {:?}", expression, prev1);
-        println!("Prev Upcoming 2 for {} {:?}", expression, prev2);
-        println!("Prev Upcoming 3 for {} {:?}", expression, prev3);
-    }
-
-    #[test]
-    fn test_upcoming_local() {
-        use chrono::Local;
-        let expression = "0 0,30 0,6,12,18 1,15 Jan-March Thurs";
-        let schedule = Schedule::from_str(expression).unwrap();
-        let mut upcoming = schedule.upcoming(Local);
-        let next1 = upcoming.next();
-        assert!(next1.is_some());
-        let next2 = upcoming.next();
-        assert!(next2.is_some());
-        let next3 = upcoming.next();
-        assert!(next3.is_some());
-        println!("Upcoming 1 for {} {:?}", expression, next1);
-        println!("Upcoming 2 for {} {:?}", expression, next2);
-        println!("Upcoming 3 for {} {:?}", expression, next3);
-    }
-
-    #[test]
-    fn test_schedule_to_string() {
-        let expression = "* 1,2,3 * * * *";
-        let schedule: Schedule = Schedule::from_str(expression).unwrap();
-        let result = String::from(schedule);
-        assert_eq!(expression, result);
-    }
-
-    #[test]
-    fn test_display_schedule() {
-        use std::fmt::Write;
-        let expression = "@monthly";
-        let schedule = Schedule::from_str(expression).unwrap();
-        let mut result = String::new();
-        write!(result, "{}", schedule).unwrap();
-        assert_eq!(expression, result);
-    }
-
-    #[test]
-    fn test_valid_from_str() {
-        let schedule = Schedule::from_str("0 0,30 0,6,12,18 1,15 Jan-March Thurs");
-        schedule.unwrap();
-    }
-
-    #[test]
-    fn test_invalid_from_str() {
-        let schedule = Schedule::from_str("cheesecake 0,30 0,6,12,18 1,15 Jan-March Thurs");
-        assert!(schedule.is_err());
-    }
-
-    #[test]
-    fn test_no_panic_on_nonexistent_time_after() {
-        use chrono::offset::TimeZone;
-        use chrono_tz::Tz;
-
-        let schedule_tz: Tz = "Europe/London".parse().unwrap();
-        let dt = schedule_tz
-            .with_ymd_and_hms(2019, 10, 27, 0, 3, 29)
-            .unwrap()
-            .checked_add_signed(chrono::Duration::hours(1)) // puts it in the middle of the DST transition
-            .unwrap();
-        let schedule = Schedule::from_str("* * * * * Sat,Sun *").unwrap();
-        let next = schedule.after(&dt).next().unwrap();
-        assert!(next > dt); // test is ensuring line above does not panic
-    }
-
-    #[test]
-    fn test_no_panic_on_nonexistent_time_before() {
-        use chrono::offset::TimeZone;
-        use chrono_tz::Tz;
-
-        let schedule_tz: Tz = "Europe/London".parse().unwrap();
-        let dt = schedule_tz
-            .with_ymd_and_hms(2019, 10, 27, 0, 3, 29)
-            .unwrap()
-            .checked_add_signed(chrono::Duration::hours(1)) // puts it in the middle of the DST transition
-            .unwrap();
-        let schedule = Schedule::from_str("* * * * * Sat,Sun *").unwrap();
-        let prev = schedule.after(&dt).nth_back(1).unwrap();
-        assert!(prev < dt); // test is ensuring line above does not panic
-    }
-
-    #[test]
-    fn test_no_panic_on_leap_day_time_after() {
-        let dt = chrono::DateTime::parse_from_rfc3339("2024-02-29T10:00:00.000+08:00").unwrap();
-        let schedule = Schedule::from_str("0 0 0 * * * 2100").unwrap();
-        let next = schedule.after(&dt).next().unwrap();
-        assert!(next > dt); // test is ensuring line above does not panic
-    }
-
-    #[test]
-    fn test_time_unit_spec_equality() {
-        let schedule_1 = Schedule::from_str("@weekly").unwrap();
-        let schedule_2 = Schedule::from_str("0 0 0 * * 1 *").unwrap();
-        let schedule_3 = Schedule::from_str("0 0 0 * * 1-7 *").unwrap();
-        let schedule_4 = Schedule::from_str("0 0 0 * * * *").unwrap();
-        assert_ne!(schedule_1, schedule_2);
-        assert!(schedule_1.timeunitspec_eq(&schedule_2));
-        assert!(schedule_3.timeunitspec_eq(&schedule_4));
-    }
-
-    #[test]
-    fn test_dst_ambiguous_time_after() {
-        use chrono_tz::Tz;
-
-        let schedule_tz: Tz = "America/Chicago".parse().unwrap();
-        let dt = schedule_tz
-            .with_ymd_and_hms(2022, 11, 5, 23, 30, 0)
-            .unwrap();
-        let schedule = Schedule::from_str("0 0 * * * * *").unwrap();
-        let times = schedule
-            .after(&dt)
-            .map(|x| x.to_string())
-            .take(5)
-            .collect::<Vec<_>>();
-        let expected_times = [
-            "2022-11-06 00:00:00 CDT".to_string(),
-            "2022-11-06 01:00:00 CDT".to_string(),
-            "2022-11-06 01:00:00 CST".to_string(), // 1 AM happens again
-            "2022-11-06 02:00:00 CST".to_string(),
-            "2022-11-06 03:00:00 CST".to_string(),
-        ];
-
-        assert_eq!(times.as_slice(), expected_times.as_slice());
-    }
-
-    #[test]
-    fn test_dst_ambiguous_time_before() {
-        use chrono_tz::Tz;
-
-        let schedule_tz: Tz = "America/Chicago".parse().unwrap();
-        let dt = schedule_tz.with_ymd_and_hms(2022, 11, 6, 3, 30, 0).unwrap();
-        let schedule = Schedule::from_str("0 0 * * * * *").unwrap();
-        let times = schedule
-            .after(&dt)
-            .map(|x| x.to_string())
-            .rev()
-            .take(5)
-            .collect::<Vec<_>>();
-        let expected_times = [
-            "2022-11-06 03:00:00 CST".to_string(),
-            "2022-11-06 02:00:00 CST".to_string(),
-            "2022-11-06 01:00:00 CST".to_string(),
-            "2022-11-06 01:00:00 CDT".to_string(), // 1 AM happens again
-            "2022-11-06 00:00:00 CDT".to_string(),
-        ];
-
-        assert_eq!(times.as_slice(), expected_times.as_slice());
     }
 }

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -81,7 +81,7 @@ impl Schedule {
                 #[cfg(feature = "vixie")]
                 let mut day_of_month_candidates = {
                     let days_of_week = self.fields.days_of_week.ordinals();
-                    
+
                     (day_of_month_start..=day_of_month_end)
                         .into_iter()
                         .filter(|dom| {

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -211,7 +211,6 @@ impl Schedule {
                     (DaysOfMonth::inclusive_min()..=day_of_month_end)
                         .into_iter()
                         .rev()
-                        .cloned()
                         .filter(|dom| {
                             if dow_and_dom_specific {
                                 return days_of_month.contains(dom)

--- a/src/time_unit/days_of_week.rs
+++ b/src/time_unit/days_of_week.rs
@@ -3,6 +3,7 @@ use crate::ordinal::{Ordinal, OrdinalSet};
 use crate::time_unit::TimeUnitField;
 use once_cell::sync::Lazy;
 use std::borrow::Cow;
+use phf::phf_map;
 
 static ALL: Lazy<OrdinalSet> = Lazy::new(DaysOfWeek::supported_ordinals);
 
@@ -10,6 +11,46 @@ static ALL: Lazy<OrdinalSet> = Lazy::new(DaysOfWeek::supported_ordinals);
 pub struct DaysOfWeek {
     ordinals: Option<OrdinalSet>,
 }
+
+#[cfg(not(feature = "vixie"))]
+static DAY_NAME_TO_ORDINAL: phf::Map<&'static str, u32> = phf_map! {
+    "sun" => 1,
+    "sunday" => 1,
+    "mon" => 2,
+    "monday" => 2,
+    "tue" => 3,
+    "tues" => 3,
+    "tuesday" => 3,
+    "wed" => 4,
+    "wednesday" => 4,
+    "thu" => 5,
+    "thurs" => 5,
+    "thursday" => 5,
+    "fri" => 6,
+    "friday" => 6,
+    "sat" => 7,
+    "saturday" => 7,
+};
+
+#[cfg(feature = "vixie")]
+static DAY_NAME_TO_ORDINAL: phf::Map<&'static str, u32> = phf_map! {
+    "sun" => 0,
+    "sunday" => 0,
+    "mon" => 1,
+    "monday" => 1,
+    "tue" => 2,
+    "tues" => 2,
+    "tuesday" => 2,
+    "wed" => 3,
+    "wednesday" => 3,
+    "thu" => 4,
+    "thurs" => 4,
+    "thursday" => 4,
+    "fri" => 5,
+    "friday" => 5,
+    "sat" => 6,
+    "saturday" => 6,
+};
 
 impl TimeUnitField for DaysOfWeek {
     fn from_optional_ordinal_set(ordinal_set: Option<OrdinalSet>) -> Self {
@@ -20,22 +61,30 @@ impl TimeUnitField for DaysOfWeek {
     fn name() -> Cow<'static, str> {
         Cow::from("Days of Week")
     }
+
+    #[cfg(not(feature = "vixie"))]
     fn inclusive_min() -> Ordinal {
         1
     }
+
+    #[cfg(not(feature = "vixie"))]
     fn inclusive_max() -> Ordinal {
         7
     }
+
+    #[cfg(feature = "vixie")]
+    fn inclusive_min() -> Ordinal {
+        0
+    }
+
+    #[cfg(feature = "vixie")]
+    fn inclusive_max() -> Ordinal {
+        6
+    }
+
     fn ordinal_from_name(name: &str) -> Result<Ordinal, Error> {
-        //TODO: Use phf crate
-        let ordinal = match name.to_lowercase().as_ref() {
-            "sun" | "sunday" => 1,
-            "mon" | "monday" => 2,
-            "tue" | "tues" | "tuesday" => 3,
-            "wed" | "wednesday" => 4,
-            "thu" | "thurs" | "thursday" => 5,
-            "fri" | "friday" => 6,
-            "sat" | "saturday" => 7,
+        match DAY_NAME_TO_ORDINAL.get(name.to_lowercase().as_str()) {
+            Some(&ordinal) => Ok(ordinal),
             _ => {
                 return Err(ErrorKind::Expression(format!(
                     "'{}' is not a valid day of the week.",
@@ -43,8 +92,7 @@ impl TimeUnitField for DaysOfWeek {
                 ))
                 .into())
             }
-        };
-        Ok(ordinal)
+        }
     }
     fn ordinals(&self) -> &OrdinalSet {
         match &self.ordinals {

--- a/src/time_unit/days_of_week.rs
+++ b/src/time_unit/days_of_week.rs
@@ -2,8 +2,8 @@ use crate::error::*;
 use crate::ordinal::{Ordinal, OrdinalSet};
 use crate::time_unit::TimeUnitField;
 use once_cell::sync::Lazy;
-use std::borrow::Cow;
 use phf::phf_map;
+use std::borrow::Cow;
 
 static ALL: Lazy<OrdinalSet> = Lazy::new(DaysOfWeek::supported_ordinals);
 

--- a/src/time_unit/months.rs
+++ b/src/time_unit/months.rs
@@ -3,8 +3,35 @@ use crate::ordinal::{Ordinal, OrdinalSet};
 use crate::time_unit::TimeUnitField;
 use once_cell::sync::Lazy;
 use std::borrow::Cow;
+use phf::phf_map;
 
 static ALL: Lazy<OrdinalSet> = Lazy::new(Months::supported_ordinals);
+
+static MONTH_NAME_TO_ORDINAL: phf::Map<&'static str, u32> = phf_map! {
+    "jan" => 1,
+    "january" => 1,
+    "feb" => 2,
+    "february" => 2,
+    "mar" => 3,
+    "march" => 3,
+    "apr" => 4,
+    "april" => 4,
+    "may" => 5,
+    "jun" => 6,
+    "june" => 6,
+    "jul" => 7,
+    "july" => 7,
+    "aug" => 8,
+    "august" => 8,
+    "sep" => 9,
+    "september" => 9,
+    "oct" => 10,
+    "october" => 10,
+    "nov" => 11,
+    "november" => 11,
+    "dec" => 12,
+    "december" => 12,
+};
 
 #[derive(Clone, Debug, Eq)]
 pub struct Months {
@@ -27,27 +54,14 @@ impl TimeUnitField for Months {
         12
     }
     fn ordinal_from_name(name: &str) -> Result<Ordinal, Error> {
-        //TODO: Use phf crate
-        let ordinal = match name.to_lowercase().as_ref() {
-            "jan" | "january" => 1,
-            "feb" | "february" => 2,
-            "mar" | "march" => 3,
-            "apr" | "april" => 4,
-            "may" => 5,
-            "jun" | "june" => 6,
-            "jul" | "july" => 7,
-            "aug" | "august" => 8,
-            "sep" | "september" => 9,
-            "oct" | "october" => 10,
-            "nov" | "november" => 11,
-            "dec" | "december" => 12,
+        match MONTH_NAME_TO_ORDINAL.get(name.to_lowercase().as_ref()) {
+            Some(&ordinal) => Ok(ordinal),
             _ => {
                 return Err(
                     ErrorKind::Expression(format!("'{}' is not a valid month name.", name)).into(),
                 )
             }
-        };
-        Ok(ordinal)
+        }
     }
     fn ordinals(&self) -> &OrdinalSet {
         match &self.ordinals {

--- a/src/time_unit/months.rs
+++ b/src/time_unit/months.rs
@@ -2,8 +2,8 @@ use crate::error::*;
 use crate::ordinal::{Ordinal, OrdinalSet};
 use crate::time_unit::TimeUnitField;
 use once_cell::sync::Lazy;
-use std::borrow::Cow;
 use phf::phf_map;
+use std::borrow::Cow;
 
 static ALL: Lazy<OrdinalSet> = Lazy::new(Months::supported_ordinals);
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -574,7 +574,6 @@ mod tests {
         assert!(first_again.is_some());
         assert_eq!(first, first_again);
 
-        
         let mut prev2 = schedule.after(&(second.unwrap() + Duration::nanoseconds(100)));
         let second_again = prev2.next_back();
         assert!(second_again.is_some());

--- a/tests/vixie.rs
+++ b/tests/vixie.rs
@@ -556,7 +556,6 @@ mod tests {
         assert!(!schedule.includes(not_included));
     }
 
-    
     #[test]
     fn test_next_and_prev_from() {
         let expression = "0 5,13,40-42 17 1 Jan *";
@@ -575,7 +574,6 @@ mod tests {
         assert!(first_again.is_some());
         assert_eq!(first, first_again);
 
-        
         let mut prev2 = schedule.after(&(second.unwrap() + Duration::nanoseconds(100)));
         let second_again = prev2.next_back();
         assert!(second_again.is_some());

--- a/tests/vixie.rs
+++ b/tests/vixie.rs
@@ -1,4 +1,4 @@
-#![cfg(all(test, not(feature = "vixie")))]
+#![cfg(all(test, feature = "vixie"))]
 mod tests {
     use chrono::*;
     use chrono_tz::Tz;
@@ -556,6 +556,7 @@ mod tests {
         assert!(!schedule.includes(not_included));
     }
 
+    
     #[test]
     fn test_next_and_prev_from() {
         let expression = "0 5,13,40-42 17 1 Jan *";
@@ -764,8 +765,8 @@ mod tests {
     #[test]
     fn test_time_unit_spec_equality() {
         let schedule_1 = Schedule::from_str("@weekly").unwrap();
-        let schedule_2 = Schedule::from_str("0 0 0 * * 1 *").unwrap();
-        let schedule_3 = Schedule::from_str("0 0 0 * * 1-7 *").unwrap();
+        let schedule_2 = Schedule::from_str("0 0 0 * * 0 *").unwrap();
+        let schedule_3 = Schedule::from_str("0 0 0 * * 0-6 *").unwrap();
         let schedule_4 = Schedule::from_str("0 0 0 * * * *").unwrap();
         assert_ne!(schedule_1, schedule_2);
         assert!(schedule_1.timeunitspec_eq(&schedule_2));


### PR DESCRIPTION
This adds a feature to switch the cron crate into a vixie compatible. Specifically it:
- changes the day of week numbering to be vixie (0-6 instead of 1-7). 
- changes the day of week and day of month conditions. If you specify a specific day of week and a specific day of month, then it will match either day of week or day of month. Otherwise both conditions must match (the Quartz way).

I also took the opportunity to convert some of the static maps to phf.

Related to #37 

Why a feature?

Using a feature is slightly strange. Features are supposed to be purely additive and this clearly isn't strictly additive. I do think that it only makes sense to either want vixie OR quartz though, meaning there's little chance of a third option coming along and complicating the feature set and that it would be strange to want to parse both formats in one program.

Also, doing this change another way would likely be sloppy. I'm generally not a fan of runtime options, that would hamper the performance and add alot of complexity to the implementations. While traiting out the Schedule is possible, making the changes to the parser is more difficult and coupling them together a bit more challenging to do cleanly.

I'm open to implementing this differently though if somebody feels strongly or just forking the crate if we'd prefer to keep it Quartz only.