### PR TITLE
Consolidate iteration into one implementation

### DIFF
--- a/src/queries.rs
+++ b/src/queries.rs
@@ -494,9 +494,9 @@ where
 }
 
 fn is_leap_year(year: Ordinal) -> bool {
-    let by_four = year % 4 == 0;
-    let by_hundred = year % 100 == 0;
-    let by_four_hundred = year % 400 == 0;
+    let by_four = year.is_multiple_of(4);
+    let by_hundred = year.is_multiple_of(100);
+    let by_four_hundred = year.is_multiple_of(400);
     by_four && ((!by_hundred) || by_four_hundred)
 }
 

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -1,15 +1,236 @@
 use chrono::offset::TimeZone;
-use chrono::{DateTime, Datelike, Duration, Timelike};
+use chrono::{DateTime, Datelike, Duration, NaiveDate, Timelike};
+use std::ops::Bound;
+use std::ops::Bound::{Included, Unbounded};
 
 use crate::ordinal::Ordinal;
+use crate::schedule::ScheduleFields;
 use crate::time_unit::{DaysOfMonth, Hours, Minutes, Months, Seconds, TimeUnitField};
 
-// TODO: Possibility of one query struct?
+pub(crate) trait Cursor<Z>
+where
+    Z: TimeZone,
+{
+    fn initial_datetime(&self) -> &DateTime<Z>;
+    fn first_month(&mut self) -> &mut bool;
+    fn first_day_of_month(&mut self) -> &mut bool;
+    fn first_hour(&mut self) -> &mut bool;
+    fn first_minute(&mut self) -> &mut bool;
+    fn first_second(&mut self) -> &mut bool;
+
+    fn cursor_month_bound(&mut self, year: Ordinal, default: Ordinal) -> Ordinal {
+        if *self.first_month() {
+            *self.first_month() = false;
+            if year == self.initial_datetime().year() as u32 {
+                return self.initial_datetime().month();
+            }
+        }
+        default
+    }
+
+    fn cursor_day_of_month_bound(&mut self, default: Ordinal) -> Ordinal {
+        if *self.first_day_of_month() {
+            *self.first_day_of_month() = false;
+            return self.initial_datetime().day();
+        }
+        default
+    }
+
+    fn cursor_hour_bound(&mut self, default: Ordinal) -> Ordinal {
+        if *self.first_hour() {
+            *self.first_hour() = false;
+            return self.initial_datetime().hour();
+        }
+        default
+    }
+
+    fn cursor_minute_bound(&mut self, default: Ordinal) -> Ordinal {
+        if *self.first_minute() {
+            *self.first_minute() = false;
+            return self.initial_datetime().minute();
+        }
+        default
+    }
+
+    fn cursor_second_bound(&mut self, default: Ordinal) -> Ordinal {
+        if *self.first_second() {
+            *self.first_second() = false;
+            return self.initial_datetime().second();
+        }
+        default
+    }
+
+    fn reset_month(&mut self) {
+        *self.first_month() = false;
+        self.reset_day_of_month();
+    }
+
+    fn reset_day_of_month(&mut self) {
+        *self.first_day_of_month() = false;
+        self.reset_hour();
+    }
+
+    fn reset_hour(&mut self) {
+        *self.first_hour() = false;
+        self.reset_minute();
+    }
+
+    fn reset_minute(&mut self) {
+        *self.first_minute() = false;
+        self.reset_second();
+    }
+
+    fn reset_second(&mut self) {
+        *self.first_second() = false;
+    }
+}
+
+pub(crate) trait Query<Z>: Cursor<Z>
+where
+    Z: TimeZone,
+{
+    fn year_range(&self) -> (Bound<Ordinal>, Bound<Ordinal>);
+    fn month_default_bound(&self) -> Ordinal;
+    fn month_range(&self, bound: Ordinal) -> (Bound<Ordinal>, Bound<Ordinal>);
+    fn day_of_month_default_bound(&self) -> Ordinal;
+    fn day_of_month_range(
+        &self,
+        bound: Ordinal,
+        day_of_month_end: Ordinal,
+    ) -> (Bound<Ordinal>, Bound<Ordinal>);
+    fn hour_default_bound(&self) -> Ordinal;
+    fn hour_range(&self, bound: Ordinal) -> (Bound<Ordinal>, Bound<Ordinal>);
+    fn minute_default_bound(&self) -> Ordinal;
+    fn minute_range(&self, bound: Ordinal) -> (Bound<Ordinal>, Bound<Ordinal>);
+    fn second_default_bound(&self) -> Ordinal;
+    fn second_range(&self, bound: Ordinal) -> (Bound<Ordinal>, Bound<Ordinal>);
+    fn is_reversed(&self) -> bool;
+    fn preceeds_reference_datetime(&self, candidate: &DateTime<Z>) -> bool;
+    fn preferred_candidate(&self, lhs: DateTime<Z>, rhs: DateTime<Z>) -> DateTime<Z>;
+
+    fn years<'a>(&self, fields: &'a ScheduleFields) -> Box<dyn Iterator<Item = &'a Ordinal> + 'a> {
+        order_iter(
+            self.is_reversed(),
+            fields.years_ordinals().range(self.year_range()),
+        )
+    }
+
+    fn months<'a>(
+        &mut self,
+        fields: &'a ScheduleFields,
+        year: Ordinal,
+    ) -> Box<dyn Iterator<Item = &'a Ordinal> + 'a> {
+        let bound = self.cursor_month_bound(year, self.month_default_bound());
+        if !fields.months_ordinals().contains(&bound) {
+            self.reset_month();
+        }
+        order_iter(
+            self.is_reversed(),
+            fields.months_ordinals().range(self.month_range(bound)),
+        )
+    }
+
+    fn days_of_month<'a>(
+        &mut self,
+        fields: &'a ScheduleFields,
+        year: Ordinal,
+        month: Ordinal,
+    ) -> Box<dyn Iterator<Item = &'a Ordinal> + 'a> {
+        let day_of_month_end = days_in_month(month, year);
+        let bound = self.cursor_day_of_month_bound(self.day_of_month_default_bound());
+
+        let range = self.day_of_month_range(bound, day_of_month_end);
+        let iter = fields
+            .days_of_month_ordinals()
+            .range(range)
+            .filter(move |day| {
+                let day = **day;
+                fields.days_of_week_is_all()
+                    || NaiveDate::from_ymd_opt(year as i32, month, day)
+                        .map(|d| fields.includes_day_of_week(d.weekday().number_from_sunday()))
+                        .unwrap_or(false)
+            });
+
+        let mut ordered = order_iter(self.is_reversed(), iter).peekable();
+        let expected_start = bound.min(day_of_month_end);
+        if ordered.peek().map(|day| **day) != Some(expected_start) {
+            self.reset_day_of_month();
+        }
+        Box::new(ordered)
+    }
+
+    fn hours<'a>(
+        &mut self,
+        fields: &'a ScheduleFields,
+    ) -> Box<dyn Iterator<Item = &'a Ordinal> + 'a> {
+        let bound = self.cursor_hour_bound(self.hour_default_bound());
+        if !fields.hours_ordinals().contains(&bound) {
+            self.reset_hour();
+        }
+        order_iter(
+            self.is_reversed(),
+            fields.hours_ordinals().range(self.hour_range(bound)),
+        )
+    }
+
+    fn minutes<'a>(
+        &mut self,
+        fields: &'a ScheduleFields,
+        fold_hour_scan: bool,
+    ) -> Box<dyn Iterator<Item = &'a Ordinal> + 'a> {
+        let query_bound = self.cursor_minute_bound(self.minute_default_bound());
+        let bound = if fold_hour_scan {
+            self.minute_default_bound()
+        } else {
+            query_bound
+        };
+        if !fields.minutes_ordinals().contains(&bound) {
+            self.reset_minute();
+        }
+        order_iter(
+            self.is_reversed(),
+            fields.minutes_ordinals().range(self.minute_range(bound)),
+        )
+    }
+
+    fn seconds<'a>(
+        &mut self,
+        fields: &'a ScheduleFields,
+        fold_hour_scan: bool,
+    ) -> Box<dyn Iterator<Item = &'a Ordinal> + 'a> {
+        let query_bound = self.cursor_second_bound(self.second_default_bound());
+        let bound = if fold_hour_scan {
+            self.second_default_bound()
+        } else {
+            query_bound
+        };
+        if !fields.seconds_ordinals().contains(&bound) {
+            self.reset_second();
+        }
+        order_iter(
+            self.is_reversed(),
+            fields.seconds_ordinals().range(self.second_range(bound)),
+        )
+    }
+}
+
+fn order_iter<'a, I, T>(reverse: bool, iter: I) -> Box<dyn Iterator<Item = T> + 'a>
+where
+    I: DoubleEndedIterator<Item = T> + 'a,
+    T: 'a,
+{
+    if reverse {
+        Box::new(iter.rev())
+    } else {
+        Box::new(iter)
+    }
+}
 
 pub struct NextAfterQuery<Z>
 where
     Z: TimeZone,
 {
+    reference_datetime: DateTime<Z>,
     initial_datetime: DateTime<Z>,
     first_month: bool,
     first_day_of_month: bool,
@@ -24,6 +245,7 @@ where
 {
     pub fn from(after: &DateTime<Z>) -> NextAfterQuery<Z> {
         NextAfterQuery {
+            reference_datetime: after.clone(),
             initial_datetime: after.clone(),
             first_month: true,
             first_day_of_month: true,
@@ -32,81 +254,114 @@ where
             first_second: true,
         }
     }
+}
 
-    pub fn year_lower_bound(&self) -> Ordinal {
-        // Unlike the other units, years will never wrap around.
-        self.initial_datetime.year() as u32
+impl<Z> Cursor<Z> for NextAfterQuery<Z>
+where
+    Z: TimeZone,
+{
+    fn initial_datetime(&self) -> &DateTime<Z> {
+        &self.initial_datetime
     }
 
-    pub fn month_lower_bound(&mut self) -> Ordinal {
-        if self.first_month {
-            self.first_month = false;
-            return self.initial_datetime.month();
-        }
+    fn first_month(&mut self) -> &mut bool {
+        &mut self.first_month
+    }
+
+    fn first_day_of_month(&mut self) -> &mut bool {
+        &mut self.first_day_of_month
+    }
+
+    fn first_hour(&mut self) -> &mut bool {
+        &mut self.first_hour
+    }
+
+    fn first_minute(&mut self) -> &mut bool {
+        &mut self.first_minute
+    }
+
+    fn first_second(&mut self) -> &mut bool {
+        &mut self.first_second
+    }
+}
+
+impl<Z> Query<Z> for NextAfterQuery<Z>
+where
+    Z: TimeZone,
+{
+    fn year_range(&self) -> (Bound<Ordinal>, Bound<Ordinal>) {
+        (Included(self.initial_datetime.year() as u32), Unbounded)
+    }
+
+    fn month_default_bound(&self) -> Ordinal {
         Months::inclusive_min()
     }
 
-    pub fn reset_month(&mut self) {
-        self.first_month = false;
-        self.reset_day_of_month();
+    fn month_range(&self, bound: Ordinal) -> (Bound<Ordinal>, Bound<Ordinal>) {
+        (Included(bound), Included(Months::inclusive_max()))
     }
 
-    pub fn day_of_month_lower_bound(&mut self) -> Ordinal {
-        if self.first_day_of_month {
-            self.first_day_of_month = false;
-            return self.initial_datetime.day();
-        }
+    fn day_of_month_default_bound(&self) -> Ordinal {
         DaysOfMonth::inclusive_min()
     }
 
-    pub fn reset_day_of_month(&mut self) {
-        self.first_day_of_month = false;
-        self.reset_hour();
+    fn day_of_month_range(
+        &self,
+        bound: Ordinal,
+        day_of_month_end: Ordinal,
+    ) -> (Bound<Ordinal>, Bound<Ordinal>) {
+        (
+            Included(bound.min(day_of_month_end)),
+            Included(day_of_month_end),
+        )
     }
 
-    pub fn hour_lower_bound(&mut self) -> Ordinal {
-        if self.first_hour {
-            self.first_hour = false;
-            return self.initial_datetime.hour();
-        }
+    fn hour_default_bound(&self) -> Ordinal {
         Hours::inclusive_min()
     }
 
-    pub fn reset_hour(&mut self) {
-        self.first_hour = false;
-        self.reset_minute();
+    fn hour_range(&self, bound: Ordinal) -> (Bound<Ordinal>, Bound<Ordinal>) {
+        (Included(bound), Included(Hours::inclusive_max()))
     }
 
-    pub fn minute_lower_bound(&mut self) -> Ordinal {
-        if self.first_minute {
-            self.first_minute = false;
-            return self.initial_datetime.minute();
-        }
+    fn minute_default_bound(&self) -> Ordinal {
         Minutes::inclusive_min()
     }
 
-    pub fn reset_minute(&mut self) {
-        self.first_minute = false;
-        self.reset_second();
+    fn minute_range(&self, bound: Ordinal) -> (Bound<Ordinal>, Bound<Ordinal>) {
+        (Included(bound), Included(Minutes::inclusive_max()))
     }
 
-    pub fn second_lower_bound(&mut self) -> Ordinal {
-        if self.first_second {
-            self.first_second = false;
-            return self.initial_datetime.second();
-        }
+    fn second_default_bound(&self) -> Ordinal {
         Seconds::inclusive_min()
     }
 
-    pub fn reset_second(&mut self) {
-        self.first_second = false;
+    fn second_range(&self, bound: Ordinal) -> (Bound<Ordinal>, Bound<Ordinal>) {
+        (Included(bound), Included(Seconds::inclusive_max()))
     }
-} // End of impl
+
+    fn is_reversed(&self) -> bool {
+        false
+    }
+
+    fn preceeds_reference_datetime(&self, candidate: &DateTime<Z>) -> bool {
+        *candidate > self.reference_datetime
+    }
+
+    fn preferred_candidate(&self, lhs: DateTime<Z>, rhs: DateTime<Z>) -> DateTime<Z> {
+        if lhs < rhs {
+            lhs
+        } else {
+            rhs
+        }
+    }
+}
 
 pub struct PrevFromQuery<Z>
 where
     Z: TimeZone,
 {
+    reference_datetime: DateTime<Z>,
     initial_datetime: DateTime<Z>,
     first_month: bool,
     first_day_of_month: bool,
@@ -126,6 +381,7 @@ where
             before.clone() - Duration::seconds(1)
         };
         PrevFromQuery {
+            reference_datetime: before.clone(),
             initial_datetime,
             first_month: true,
             first_day_of_month: true,
@@ -134,73 +390,122 @@ where
             first_second: true,
         }
     }
+}
 
-    pub fn year_upper_bound(&self) -> Ordinal {
-        // Unlike the other units, years will never wrap around.
-        self.initial_datetime.year() as u32
+impl<Z> Cursor<Z> for PrevFromQuery<Z>
+where
+    Z: TimeZone,
+{
+    fn initial_datetime(&self) -> &DateTime<Z> {
+        &self.initial_datetime
     }
 
-    pub fn month_upper_bound(&mut self) -> Ordinal {
-        if self.first_month {
-            self.first_month = false;
-            return self.initial_datetime.month();
-        }
+    fn first_month(&mut self) -> &mut bool {
+        &mut self.first_month
+    }
+
+    fn first_day_of_month(&mut self) -> &mut bool {
+        &mut self.first_day_of_month
+    }
+
+    fn first_hour(&mut self) -> &mut bool {
+        &mut self.first_hour
+    }
+
+    fn first_minute(&mut self) -> &mut bool {
+        &mut self.first_minute
+    }
+
+    fn first_second(&mut self) -> &mut bool {
+        &mut self.first_second
+    }
+}
+
+impl<Z> Query<Z> for PrevFromQuery<Z>
+where
+    Z: TimeZone,
+{
+    fn year_range(&self) -> (Bound<Ordinal>, Bound<Ordinal>) {
+        (Unbounded, Included(self.initial_datetime.year() as u32))
+    }
+
+    fn month_default_bound(&self) -> Ordinal {
         Months::inclusive_max()
     }
 
-    pub fn reset_month(&mut self) {
-        self.first_month = false;
-        self.reset_day_of_month();
+    fn month_range(&self, bound: Ordinal) -> (Bound<Ordinal>, Bound<Ordinal>) {
+        (Included(Months::inclusive_min()), Included(bound))
     }
 
-    pub fn day_of_month_upper_bound(&mut self) -> Ordinal {
-        if self.first_day_of_month {
-            self.first_day_of_month = false;
-            return self.initial_datetime.day();
-        }
+    fn day_of_month_default_bound(&self) -> Ordinal {
         DaysOfMonth::inclusive_max()
     }
 
-    pub fn reset_day_of_month(&mut self) {
-        self.first_day_of_month = false;
-        self.reset_hour();
+    fn day_of_month_range(
+        &self,
+        bound: Ordinal,
+        day_of_month_end: Ordinal,
+    ) -> (Bound<Ordinal>, Bound<Ordinal>) {
+        (
+            Included(DaysOfMonth::inclusive_min()),
+            Included(bound.min(day_of_month_end)),
+        )
     }
 
-    pub fn hour_upper_bound(&mut self) -> Ordinal {
-        if self.first_hour {
-            self.first_hour = false;
-            return self.initial_datetime.hour();
-        }
+    fn hour_default_bound(&self) -> Ordinal {
         Hours::inclusive_max()
     }
 
-    pub fn reset_hour(&mut self) {
-        self.first_hour = false;
-        self.reset_minute();
+    fn hour_range(&self, bound: Ordinal) -> (Bound<Ordinal>, Bound<Ordinal>) {
+        (Included(Hours::inclusive_min()), Included(bound))
     }
 
-    pub fn minute_upper_bound(&mut self) -> Ordinal {
-        if self.first_minute {
-            self.first_minute = false;
-            return self.initial_datetime.minute();
-        }
+    fn minute_default_bound(&self) -> Ordinal {
         Minutes::inclusive_max()
     }
 
-    pub fn reset_minute(&mut self) {
-        self.first_minute = false;
-        self.reset_second();
+    fn minute_range(&self, bound: Ordinal) -> (Bound<Ordinal>, Bound<Ordinal>) {
+        (Included(Minutes::inclusive_min()), Included(bound))
     }
 
-    pub fn second_upper_bound(&mut self) -> Ordinal {
-        if self.first_second {
-            self.first_second = false;
-            return self.initial_datetime.second();
-        }
+    fn second_default_bound(&self) -> Ordinal {
         Seconds::inclusive_max()
     }
 
-    pub fn reset_second(&mut self) {
-        self.first_second = false;
+    fn second_range(&self, bound: Ordinal) -> (Bound<Ordinal>, Bound<Ordinal>) {
+        (Included(Seconds::inclusive_min()), Included(bound))
+    }
+
+    fn is_reversed(&self) -> bool {
+        true
+    }
+
+    fn preceeds_reference_datetime(&self, candidate: &DateTime<Z>) -> bool {
+        *candidate < self.reference_datetime
+    }
+
+    fn preferred_candidate(&self, lhs: DateTime<Z>, rhs: DateTime<Z>) -> DateTime<Z> {
+        if lhs > rhs {
+            lhs
+        } else {
+            rhs
+        }
+    }
+}
+
+fn is_leap_year(year: Ordinal) -> bool {
+    let by_four = year % 4 == 0;
+    let by_hundred = year % 100 == 0;
+    let by_four_hundred = year % 400 == 0;
+    by_four && ((!by_hundred) || by_four_hundred)
+}
+
+fn days_in_month(month: Ordinal, year: Ordinal) -> u32 {
+    let is_leap_year = is_leap_year(year);
+    match month {
+        9 | 4 | 6 | 11 => 30,
+        2 if is_leap_year => 29,
+        2 => 28,
+        _ => 31,
     }
 }

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -1,8 +1,6 @@
 use chrono::offset::{LocalResult, TimeZone};
-use chrono::{DateTime, Datelike, NaiveDate, Timelike, Utc};
-use std::cmp::{max, min};
+use chrono::{DateTime, Datelike, Timelike, Utc};
 use std::fmt::{Display, Formatter, Result as FmtResult};
-use std::ops::Bound::{Included, Unbounded};
 
 #[cfg(feature = "serde")]
 use core::fmt;
@@ -37,374 +35,97 @@ impl Schedule {
     where
         Z: TimeZone,
     {
-        let mut query = NextAfterQuery::from(after);
-        // Ambiguous naive datetimes translate to two local datetimes. This
-        // iteration uses naive datetimes and could skip the second local
-        // datetime, where the second may match the pattern. This deferred
-        // candidate retains that datetime for consideration on subsequent
-        // iterations. For example, during fall back, `0 0/30 * * * * *` must
-        // emit both 01:30 local datetimes.
-        let mut deferred_candidate: Option<DateTime<Z>> = None;
-        // Folded time happens during the fall back DST transition where an
-        // offset, typically one hour, is repeated in both timezones. This flag
-        // tells iteration it is starting in the first repeated offset so it
-        // does not get stuck repeating matches from the first fold or skip
-        // matches in the second fold.
-        let after_naive = after.naive_local();
-        let after_in_first_fold = match after.timezone().from_local_datetime(&after_naive) {
-            LocalResult::Ambiguous(first, second) => {
-                let earlier = min(first, second);
-                *after == earlier
-            }
-            _ => false,
-        };
-        for year in self
-            .fields
-            .years
-            .ordinals()
-            .range((Included(query.year_lower_bound()), Unbounded))
-            .cloned()
-        {
-            // It's a future year, the current year's range is irrelevant.
-            if year > after.year() as u32 {
-                query.reset_month();
-            }
-            let month_start = query.month_lower_bound();
-            if !self.fields.months.ordinals().contains(&month_start) {
-                query.reset_month();
-            }
-            let month_range = (Included(month_start), Included(Months::inclusive_max()));
-            for month in self.fields.months.ordinals().range(month_range).cloned() {
-                let day_of_month_start = query.day_of_month_lower_bound();
-                if !self
-                    .fields
-                    .days_of_month
-                    .ordinals()
-                    .contains(&day_of_month_start)
-                {
-                    query.reset_day_of_month();
-                }
-                let day_of_month_end = days_in_month(month, year);
-                let day_of_month_range = (
-                    Included(day_of_month_start.min(day_of_month_end)),
-                    Included(day_of_month_end),
-                );
-
-                let mut day_iter = self
-                    .fields
-                    .days_of_month
-                    .ordinals()
-                    .range(day_of_month_range)
-                    .cloned()
-                    .filter(|&day| {
-                        self.fields.days_of_week.is_all()
-                            || NaiveDate::from_ymd_opt(year as i32, month, day)
-                                .map(|d| {
-                                    self.fields
-                                        .days_of_week
-                                        .ordinals()
-                                        .contains(&d.weekday().number_from_sunday())
-                                })
-                                .unwrap_or(false)
-                    })
-                    .peekable();
-                if day_iter.peek() != Some(&day_of_month_start) {
-                    query.reset_day_of_month();
-                }
-                for day_of_month in day_iter {
-                    let hour_start = query.hour_lower_bound();
-                    if !self.fields.hours.ordinals().contains(&hour_start) {
-                        query.reset_hour();
-                    }
-                    let hour_range = (Included(hour_start), Included(Hours::inclusive_max()));
-
-                    for hour in self.fields.hours.ordinals().range(hour_range).cloned() {
-                        // The first fold is the first repeat of the DST offset,
-                        // typically one hour. Because this iteration is done in
-                        // naive time, it can skip matches after finding one in
-                        // the first fold. For example, `0 0/30 * * * * *` must
-                        // continue from 01:00 to 01:30 in both folds.
-                        let fold_hour_scan = after_in_first_fold
-                            && year as i32 == after_naive.year()
-                            && month == after_naive.month()
-                            && day_of_month == after_naive.day()
-                            && hour == after_naive.hour();
-                        let query_minute_start = query.minute_lower_bound();
-                        let minute_start = if fold_hour_scan {
-                            Minutes::inclusive_min()
-                        } else {
-                            query_minute_start
-                        };
-                        if !self.fields.minutes.ordinals().contains(&minute_start) {
-                            query.reset_minute();
-                        }
-                        let minute_range =
-                            (Included(minute_start), Included(Minutes::inclusive_max()));
-
-                        for minute in self.fields.minutes.ordinals().range(minute_range).cloned() {
-                            let query_second_start = query.second_lower_bound();
-                            let second_start = if fold_hour_scan {
-                                Seconds::inclusive_min()
-                            } else {
-                                query_second_start
-                            };
-                            if !self.fields.seconds.ordinals().contains(&second_start) {
-                                query.reset_second();
-                            }
-                            let second_range =
-                                (Included(second_start), Included(Seconds::inclusive_max()));
-
-                            for second in
-                                self.fields.seconds.ordinals().range(second_range).cloned()
-                            {
-                                let timezone = after.timezone();
-                                let local_result = timezone.with_ymd_and_hms(
-                                    year as i32,
-                                    month,
-                                    day_of_month,
-                                    hour,
-                                    minute,
-                                    second,
-                                );
-                                match local_result {
-                                    LocalResult::None => continue,
-                                    LocalResult::Single(candidate) => {
-                                        if candidate <= *after {
-                                            continue;
-                                        }
-                                        if let Some(deferred) = deferred_candidate.take() {
-                                            return Some(min(deferred, candidate));
-                                        }
-                                        return Some(candidate);
-                                    }
-                                    LocalResult::Ambiguous(earlier, later) => {
-                                        if earlier > *after {
-                                            if let Some(deferred) = deferred_candidate.take() {
-                                                return Some(min(deferred, earlier));
-                                            }
-                                            return Some(earlier);
-                                        }
-                                        if later > *after {
-                                            deferred_candidate = Some(match deferred_candidate {
-                                                Some(existing) => min(existing, later),
-                                                _ => later,
-                                            });
-                                        }
-                                    }
-                                }
-                            }
-                            query.reset_minute();
-                        } // End of minutes range
-                        query.reset_hour();
-                    } // End of hours range
-                    query.reset_day_of_month();
-                } // End of Day of Month range
-                query.reset_month();
-            } // End of Month range
-        }
-
-        if let Some(candidate) = deferred_candidate {
-            return Some(candidate);
-        }
-        // We ran out of dates to try.
-        None
+        self.find_with_query(NextAfterQuery::from(after), after)
     }
 
     fn prev_from<Z>(&self, before: &DateTime<Z>) -> Option<DateTime<Z>>
     where
         Z: TimeZone,
     {
-        let mut query = PrevFromQuery::from(before);
-        // See `next_after` for folded-time details. This is the reverse scan's
-        // deferred candidate for an earlier local datetime that may still be
-        // the previous chronological match.
+        self.find_with_query(PrevFromQuery::from(before), before)
+    }
+
+    fn find_with_query<Z, Q>(&self, mut query: Q, datetime: &DateTime<Z>) -> Option<DateTime<Z>>
+    where
+        Z: TimeZone,
+        Q: Query<Z>,
+    {
         let mut deferred_candidate: Option<DateTime<Z>> = None;
-        // See `next_after` for folded-time details. This flag handles starting
-        // from the second fold while scanning backward.
-        let before_naive = before.naive_local();
-        let before_in_second_fold = match before.timezone().from_local_datetime(&before_naive) {
+        let reference_naive = datetime.naive_local();
+        let fold_scan_active = match datetime.timezone().from_local_datetime(&reference_naive) {
             LocalResult::Ambiguous(first, second) => {
-                let later = max(first, second);
-                *before == later
+                *datetime == query.preferred_candidate(first, second)
             }
             _ => false,
         };
-        for year in self
-            .fields
-            .years
-            .ordinals()
-            .range((Unbounded, Included(query.year_upper_bound())))
-            .rev()
-            .cloned()
-        {
-            let month_start = query.month_upper_bound();
-
-            if !self.fields.months.ordinals().contains(&month_start) {
-                query.reset_month();
-            }
-            let month_range = (Included(Months::inclusive_min()), Included(month_start));
-
-            for month in self
-                .fields
-                .months
-                .ordinals()
-                .range(month_range)
-                .rev()
-                .cloned()
-            {
-                let day_of_month_end = query.day_of_month_upper_bound();
-                if !self
-                    .fields
-                    .days_of_month
-                    .ordinals()
-                    .contains(&day_of_month_end)
-                {
-                    query.reset_day_of_month();
-                }
-
-                let day_of_month_end = days_in_month(month, year).min(day_of_month_end);
-
-                let day_of_month_range = (
-                    Included(DaysOfMonth::inclusive_min()),
-                    Included(day_of_month_end),
-                );
-
-                let mut day_iter = self
-                    .fields
-                    .days_of_month
-                    .ordinals()
-                    .range(day_of_month_range)
-                    .rev()
-                    .cloned()
-                    .filter(|&day| {
-                        self.fields.days_of_week.is_all()
-                            || NaiveDate::from_ymd_opt(year as i32, month, day)
-                                .map(|d| {
-                                    self.fields
-                                        .days_of_week
-                                        .ordinals()
-                                        .contains(&d.weekday().number_from_sunday())
-                                })
-                                .unwrap_or(false)
-                    })
-                    .peekable();
-                if day_iter.peek() != Some(&day_of_month_end) {
-                    query.reset_day_of_month();
-                }
-                for day_of_month in day_iter {
-                    let hour_start = query.hour_upper_bound();
-                    if !self.fields.hours.ordinals().contains(&hour_start) {
-                        query.reset_hour();
-                    }
-                    let hour_range = (Included(Hours::inclusive_min()), Included(hour_start));
-
-                    for hour in self
-                        .fields
-                        .hours
-                        .ordinals()
-                        .range(hour_range)
-                        .rev()
-                        .cloned()
-                    {
-                        // See the forward `fold_hour_scan` for folded-time
-                        // details. This is the reverse scan of the repeated
-                        // hour from the second fold into the first.
-                        let fold_hour_scan = before_in_second_fold
-                            && year as i32 == before_naive.year()
-                            && month == before_naive.month()
-                            && day_of_month == before_naive.day()
-                            && hour == before_naive.hour();
-                        let query_minute_start = query.minute_upper_bound();
-                        let minute_start = if fold_hour_scan {
-                            Minutes::inclusive_max()
-                        } else {
-                            query_minute_start
-                        };
-                        if !self.fields.minutes.ordinals().contains(&minute_start) {
-                            query.reset_minute();
-                        }
-                        let minute_range =
-                            (Included(Minutes::inclusive_min()), Included(minute_start));
-
-                        for minute in self
-                            .fields
-                            .minutes
-                            .ordinals()
-                            .range(minute_range)
-                            .rev()
-                            .cloned()
-                        {
-                            let query_second_start = query.second_upper_bound();
-                            let second_start = if fold_hour_scan {
-                                Seconds::inclusive_max()
-                            } else {
-                                query_second_start
-                            };
-                            if !self.fields.seconds.ordinals().contains(&second_start) {
-                                query.reset_second();
-                            }
-                            let second_range =
-                                (Included(Seconds::inclusive_min()), Included(second_start));
-
-                            for second in self
-                                .fields
-                                .seconds
-                                .ordinals()
-                                .range(second_range)
-                                .rev()
-                                .cloned()
-                            {
-                                let timezone = before.timezone();
-                                let local_result = timezone.with_ymd_and_hms(
-                                    year as i32,
-                                    month,
-                                    day_of_month,
-                                    hour,
-                                    minute,
-                                    second,
+        for year in query.years(&self.fields) {
+            for month in query.months(&self.fields, *year) {
+                for day_of_month in query.days_of_month(&self.fields, *year, *month) {
+                    for hour in query.hours(&self.fields) {
+                        let fold_hour_scan = fold_scan_active
+                            && *year as i32 == reference_naive.year()
+                            && *month == reference_naive.month()
+                            && *day_of_month == reference_naive.day()
+                            && *hour == reference_naive.hour();
+                        for minute in query.minutes(&self.fields, fold_hour_scan) {
+                            for second in query.seconds(&self.fields, fold_hour_scan) {
+                                let local_result = datetime.timezone().with_ymd_and_hms(
+                                    *year as i32,
+                                    *month,
+                                    *day_of_month,
+                                    *hour,
+                                    *minute,
+                                    *second,
                                 );
                                 match local_result {
                                     LocalResult::None => continue,
                                     LocalResult::Single(candidate) => {
-                                        if candidate >= *before {
+                                        if !query.preceeds_reference_datetime(&candidate) {
                                             continue;
                                         }
                                         if let Some(deferred) = deferred_candidate.take() {
-                                            return Some(max(deferred, candidate));
+                                            return Some(
+                                                query.preferred_candidate(deferred, candidate),
+                                            );
                                         }
                                         return Some(candidate);
                                     }
                                     LocalResult::Ambiguous(earlier, later) => {
-                                        if later < *before {
+                                        let primary = query
+                                            .preferred_candidate(earlier.clone(), later.clone());
+                                        if query.preceeds_reference_datetime(&primary) {
                                             if let Some(deferred) = deferred_candidate.take() {
-                                                return Some(max(deferred, later));
+                                                return Some(
+                                                    query.preferred_candidate(deferred, primary),
+                                                );
                                             }
-                                            return Some(later);
+                                            return Some(primary);
                                         }
-                                        if earlier < *before {
-                                            deferred_candidate = Some(match deferred_candidate {
-                                                Some(existing) => max(existing, earlier),
-                                                _ => earlier,
-                                            });
+
+                                        let secondary =
+                                            if primary == earlier { later } else { earlier };
+                                        if query.preceeds_reference_datetime(&secondary) {
+                                            deferred_candidate =
+                                                Some(match deferred_candidate.take() {
+                                                    Some(existing) => query
+                                                        .preferred_candidate(existing, secondary),
+                                                    None => secondary,
+                                                });
                                         }
                                     }
                                 }
                             }
                             query.reset_minute();
-                        } // End of minutes range
+                        }
                         query.reset_hour();
-                    } // End of hours range
+                    }
                     query.reset_day_of_month();
-                } // End of Day of Month range
+                }
                 query.reset_month();
-            } // End of Month range
+            }
         }
 
-        if let Some(candidate) = deferred_candidate {
-            return Some(candidate);
-        }
-        // We ran out of dates to try.
-        None
+        deferred_candidate
     }
 
     /// Provides an iterator which will return each DateTime that matches the schedule starting with
@@ -541,6 +262,38 @@ impl ScheduleFields {
             seconds,
         }
     }
+
+    pub(crate) fn years_ordinals(&self) -> &OrdinalSet {
+        self.years.ordinals()
+    }
+
+    pub(crate) fn months_ordinals(&self) -> &OrdinalSet {
+        self.months.ordinals()
+    }
+
+    pub(crate) fn days_of_month_ordinals(&self) -> &OrdinalSet {
+        self.days_of_month.ordinals()
+    }
+
+    pub(crate) fn hours_ordinals(&self) -> &OrdinalSet {
+        self.hours.ordinals()
+    }
+
+    pub(crate) fn minutes_ordinals(&self) -> &OrdinalSet {
+        self.minutes.ordinals()
+    }
+
+    pub(crate) fn seconds_ordinals(&self) -> &OrdinalSet {
+        self.seconds.ordinals()
+    }
+
+    pub(crate) fn days_of_week_is_all(&self) -> bool {
+        self.days_of_week.is_all()
+    }
+
+    pub(crate) fn includes_day_of_week(&self, day_of_week: Ordinal) -> bool {
+        self.days_of_week.ordinals().contains(&day_of_week)
+    }
 }
 
 pub struct ScheduleIterator<'a, Z>
@@ -635,23 +388,6 @@ impl<Z: TimeZone> DoubleEndedIterator for OwnedScheduleIterator<Z> {
         let prev = self.schedule.prev_from(&previous)?;
         self.previous_datetime = Some(prev.clone());
         Some(prev)
-    }
-}
-
-fn is_leap_year(year: Ordinal) -> bool {
-    let by_four = year.is_multiple_of(4);
-    let by_hundred = year.is_multiple_of(100);
-    let by_four_hundred = year.is_multiple_of(400);
-    by_four && ((!by_hundred) || by_four_hundred)
-}
-
-fn days_in_month(month: Ordinal, year: Ordinal) -> u32 {
-    let is_leap_year = is_leap_year(year);
-    match month {
-        9 | 4 | 6 | 11 => 30,
-        2 if is_leap_year => 29,
-        2 => 28,
-        _ => 31,
     }
 }
 


### PR DESCRIPTION
There's a TODO in the query file to reduce the query structs into one that's agnostic of iteration direction. I think at this point the schedule iteration is more complicated and repeated than the query. So what I did is make the schedule iteration agnostic of direction by moving more of the "directionality" into the query structs. 