### PR TITLE
Support configurable cron year fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,13 @@ name = "cron"
 
 [dependencies]
 chrono = { version = "~0.4", default-features = false, features = ["clock"] }
+chrono-tz = "~0.10"
 winnow = "0.7.0"
 once_cell = "1.10"
 phf = { version = "0.11", features = ["macros"] }
 serde = {version = "1.0.164", optional = true }
 
 [dev-dependencies]
-chrono-tz = "~0.6"
 serde_test = "1.0.164"
 
 # Dev-dependency for feature "serde".

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ chrono = { version = "~0.4", default-features = false, features = ["clock"] }
 chrono-tz = "~0.10"
 winnow = "0.7.0"
 once_cell = "1.10"
-phf = { version = "0.11", features = ["macros"] }
+phf = { version = "0.12", features = ["macros"] }
 serde = {version = "1.0.164", optional = true }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -31,6 +31,46 @@ Upcoming fire times:
 */
 ```
 
+## Parsing With Config Options
+
+`Schedule::from_str(...)` uses the default config.
+
+If you need custom behavior, use the builder:
+
+```rust
+use chrono::TimeDelta;
+use cron::{CronScheduleParts, DayOfWeekNumbering, DowDomOperand, Schedule};
+
+let schedule = Schedule::builder()
+    .allowed_cron_schedule_parts(CronScheduleParts::Both) // 5-part and 6-part expressions
+    .day_of_week_numbering(DayOfWeekNumbering::ZeroToSix) // Vixie-style DOW numbering
+    .dow_dom_operand(DowDomOperand::Or)                   // combine DOM + DOW with OR
+    .search_interval(TimeDelta::days(400 * 366))          // bound search window
+    .parse("30 9 1 * 1")
+    .unwrap();
+```
+
+Convenience constructors:
+
+```rust
+use cron::{CronScheduleParts, Schedule};
+
+let custom = Schedule::builder()
+    .allowed_cron_schedule_parts(CronScheduleParts::Both)
+    .parse("30 9 * * Mon")
+    .unwrap();
+
+let default = Schedule::default().parse("0 30 9 * * Mon").unwrap();
+let vixie = Schedule::vixie().parse("0 0 0 * * 0").unwrap();
+```
+
+Default config values:
+
+- `cron_schedule_parts`: `CronScheduleParts::Six`
+- `day_of_week_numbering`: `DayOfWeekNumbering::OneToSeven`
+- `dow_dom_operand`: `DowDomOperand::And`
+- `search_interval`: `400 * 366` days
+
 ## License
 
 Licensed under either of

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ use cron::{
 };
 
 let schedule = Schedule::builder()
-    .allowed_cron_schedule_parts(CronScheduleParts::Both) // 5-part and 6-part expressions
+    .allowed_cron_schedule_parts(CronScheduleParts::All) // 5-, 6-, or 7-part expressions
     .day_of_week_numbering(DayOfWeekNumbering::ZeroIndexed) // Vixie-style DOW numbering
     .wraparound_ranges(true)                       // allow ranges like Nov-Mar
     .dow_dom_operand(DowDomOperand::Or)                   // combine DOM + DOW with OR
@@ -60,8 +60,13 @@ Convenience constructors:
 use cron::{CronScheduleParts, Schedule};
 
 let custom = Schedule::builder()
-    .allowed_cron_schedule_parts(CronScheduleParts::Both)
+    .allowed_cron_schedule_parts(CronScheduleParts::FiveOrSix)
     .parse("30 9 * * Mon")
+    .unwrap();
+
+let with_year = Schedule::builder()
+    .allowed_cron_schedule_parts(CronScheduleParts::Seven)
+    .parse("0 0 0 1 1 * 2020/2")
     .unwrap();
 
 let default = Schedule::default().parse("0 30 9 * * Mon").unwrap();
@@ -70,12 +75,14 @@ let vixie = Schedule::vixie().parse("0 0 0 * Nov-Mar 7-mon").unwrap();
 
 Default config values:
 
-- `cron_schedule_parts`: `CronScheduleParts::Six`
+- `cron_schedule_parts`: `CronScheduleParts::SixOrSeven`
 - `day_of_week_numbering`: `DayOfWeekNumbering::OneIndexed`
 - `wraparound_ranges`: `false`
 - `dow_dom_operand`: `DowDomOperand::And`
 - `nonexistent_time_behavior`: `NonexistentTimeBehavior::Skip`
 - `search_interval`: `400 * 366` days
+
+The optional year field is the seventh field. Open-ended year searches are bounded by the configured `search_interval`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ use cron::{CronScheduleParts, DayOfWeekNumbering, DowDomOperand, Schedule};
 
 let schedule = Schedule::builder()
     .allowed_cron_schedule_parts(CronScheduleParts::Both) // 5-part and 6-part expressions
-    .day_of_week_numbering(DayOfWeekNumbering::ZeroToSix) // Vixie-style DOW numbering
+    .day_of_week_numbering(DayOfWeekNumbering::ZeroIndexed) // Vixie-style DOW numbering
+    .wraparound_ranges(true)                       // allow ranges like Nov-Mar
     .dow_dom_operand(DowDomOperand::Or)                   // combine DOM + DOW with OR
     .search_interval(TimeDelta::days(400 * 366))          // bound search window
     .parse("30 9 1 * 1")
@@ -61,13 +62,14 @@ let custom = Schedule::builder()
     .unwrap();
 
 let default = Schedule::default().parse("0 30 9 * * Mon").unwrap();
-let vixie = Schedule::vixie().parse("0 0 0 * * 0").unwrap();
+let vixie = Schedule::vixie().parse("0 0 0 * Nov-Mar 7-mon").unwrap();
 ```
 
 Default config values:
 
 - `cron_schedule_parts`: `CronScheduleParts::Six`
-- `day_of_week_numbering`: `DayOfWeekNumbering::OneToSeven`
+- `day_of_week_numbering`: `DayOfWeekNumbering::OneIndexed`
+- `wraparound_ranges`: `false`
 - `dow_dom_operand`: `DowDomOperand::And`
 - `search_interval`: `400 * 366` days
 

--- a/README.md
+++ b/README.md
@@ -39,13 +39,16 @@ If you need custom behavior, use the builder:
 
 ```rust
 use chrono::TimeDelta;
-use cron::{CronScheduleParts, DayOfWeekNumbering, DowDomOperand, Schedule};
+use cron::{
+    CronScheduleParts, DayOfWeekNumbering, DowDomOperand, NonexistentTimeBehavior, Schedule,
+};
 
 let schedule = Schedule::builder()
     .allowed_cron_schedule_parts(CronScheduleParts::Both) // 5-part and 6-part expressions
     .day_of_week_numbering(DayOfWeekNumbering::ZeroIndexed) // Vixie-style DOW numbering
     .wraparound_ranges(true)                       // allow ranges like Nov-Mar
     .dow_dom_operand(DowDomOperand::Or)                   // combine DOM + DOW with OR
+    .nonexistent_time_behavior(NonexistentTimeBehavior::NextExistent) // map skipped local times
     .search_interval(TimeDelta::days(400 * 366))          // bound search window
     .parse("30 9 1 * 1")
     .unwrap();
@@ -71,6 +74,7 @@ Default config values:
 - `day_of_week_numbering`: `DayOfWeekNumbering::OneIndexed`
 - `wraparound_ranges`: `false`
 - `dow_dom_operand`: `DowDomOperand::And`
+- `nonexistent_time_behavior`: `NonexistentTimeBehavior::Skip`
 - `search_interval`: `400 * 366` days
 
 ## License

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,50 @@
+use chrono::TimeDelta;
+
+/// Controls which cron expression variants are accepted by the parser.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CronScheduleParts {
+    /// Accept only 5-part expressions: minute hour day-of-month month day-of-week.
+    Five,
+    /// Accept only 6-part expressions: second minute hour day-of-month month day-of-week.
+    Six,
+    /// Accept both 5-part and 6-part expressions.
+    Both,
+}
+
+/// Controls accepted day-of-week numeric notation in cron expressions.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DayOfWeekNumbering {
+    /// Sunday=1 through Saturday=7.
+    OneToSeven,
+    /// Sunday=0 through Saturday=6.
+    ZeroToSix,
+}
+
+/// Controls how day-of-month and day-of-week fields are combined.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DowDomOperand {
+    /// Both day-of-month and day-of-week must match when both are restricted.
+    And,
+    /// Either day-of-month or day-of-week may match when both are restricted.
+    Or,
+}
+
+/// Parsing and interpretation configuration for cron schedules.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ScheduleConfig {
+    pub cron_schedule_parts: CronScheduleParts,
+    pub day_of_week_numbering: DayOfWeekNumbering,
+    pub dow_dom_operand: DowDomOperand,
+    pub search_interval: TimeDelta,
+}
+
+impl Default for ScheduleConfig {
+    fn default() -> Self {
+        Self {
+            cron_schedule_parts: CronScheduleParts::Six,
+            day_of_week_numbering: DayOfWeekNumbering::OneToSeven,
+            dow_dom_operand: DowDomOperand::And,
+            search_interval: TimeDelta::days(400 * 366),
+        }
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,8 +7,14 @@ pub enum CronScheduleParts {
     Five,
     /// Accept only 6-part expressions: second minute hour day-of-month month day-of-week.
     Six,
-    /// Accept both 5-part and 6-part expressions.
-    Both,
+    /// Accept only 7-part expressions: second minute hour day-of-month month day-of-week year.
+    Seven,
+    /// Accept 5- or 6-part expressions.
+    FiveOrSix,
+    /// Accept 6- or 7-part expressions.
+    SixOrSeven,
+    /// Accept 5-, 6-, or 7-part expressions.
+    All,
 }
 
 /// Controls accepted day-of-week numeric notation in cron expressions.
@@ -52,7 +58,7 @@ pub struct ScheduleConfig {
 impl Default for ScheduleConfig {
     fn default() -> Self {
         Self {
-            cron_schedule_parts: CronScheduleParts::Six,
+            cron_schedule_parts: CronScheduleParts::SixOrSeven,
             day_of_week_numbering: DayOfWeekNumbering::OneIndexed,
             wraparound_ranges: false,
             dow_dom_operand: DowDomOperand::And,

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,6 +29,15 @@ pub enum DowDomOperand {
     Or,
 }
 
+/// Controls how nonexistent local times are handled during schedule iteration.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum NonexistentTimeBehavior {
+    /// Skip scheduled local times that do not exist in the configured time zone.
+    Skip,
+    /// Return the next existent time after a scheduled local time that does not exist.
+    NextExistent,
+}
+
 /// Parsing and interpretation configuration for cron schedules.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ScheduleConfig {
@@ -36,6 +45,7 @@ pub struct ScheduleConfig {
     pub day_of_week_numbering: DayOfWeekNumbering,
     pub wraparound_ranges: bool,
     pub dow_dom_operand: DowDomOperand,
+    pub nonexistent_time_behavior: NonexistentTimeBehavior,
     pub search_interval: TimeDelta,
 }
 
@@ -46,6 +56,7 @@ impl Default for ScheduleConfig {
             day_of_week_numbering: DayOfWeekNumbering::OneIndexed,
             wraparound_ranges: false,
             dow_dom_operand: DowDomOperand::And,
+            nonexistent_time_behavior: NonexistentTimeBehavior::Skip,
             search_interval: TimeDelta::days(400 * 366),
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,9 +15,9 @@ pub enum CronScheduleParts {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum DayOfWeekNumbering {
     /// Sunday=1 through Saturday=7.
-    OneToSeven,
-    /// Sunday=0 through Saturday=6.
-    ZeroToSix,
+    OneIndexed,
+    /// Sunday=0 or 7, Monday=1 through Saturday=6.
+    ZeroIndexed,
 }
 
 /// Controls how day-of-month and day-of-week fields are combined.
@@ -34,6 +34,7 @@ pub enum DowDomOperand {
 pub struct ScheduleConfig {
     pub cron_schedule_parts: CronScheduleParts,
     pub day_of_week_numbering: DayOfWeekNumbering,
+    pub wraparound_ranges: bool,
     pub dow_dom_operand: DowDomOperand,
     pub search_interval: TimeDelta,
 }
@@ -42,7 +43,8 @@ impl Default for ScheduleConfig {
     fn default() -> Self {
         Self {
             cron_schedule_parts: CronScheduleParts::Six,
-            day_of_week_numbering: DayOfWeekNumbering::OneToSeven,
+            day_of_week_numbering: DayOfWeekNumbering::OneIndexed,
+            wraparound_ranges: false,
             dow_dom_operand: DowDomOperand::And,
             search_interval: TimeDelta::days(400 * 366),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@
 /// Error types used by this crate.
 pub mod error;
 
+mod config;
 mod ordinal;
 mod parsing;
 mod queries;
@@ -43,5 +44,8 @@ mod schedule;
 mod specifier;
 mod time_unit;
 
-pub use crate::schedule::{OwnedScheduleIterator, Schedule, ScheduleIterator};
+pub use crate::config::{CronScheduleParts, DayOfWeekNumbering, DowDomOperand, ScheduleConfig};
+pub use crate::schedule::{
+    OwnedScheduleIterator, Schedule, ScheduleConfigBuilder, ScheduleIterator,
+};
 pub use crate::time_unit::TimeUnitSpec;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,9 @@ mod schedule;
 mod specifier;
 mod time_unit;
 
-pub use crate::config::{CronScheduleParts, DayOfWeekNumbering, DowDomOperand, ScheduleConfig};
+pub use crate::config::{
+    CronScheduleParts, DayOfWeekNumbering, DowDomOperand, NonexistentTimeBehavior, ScheduleConfig,
+};
 pub use crate::schedule::{
     OwnedScheduleIterator, Schedule, ScheduleConfigBuilder, ScheduleIterator,
 };

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -6,19 +6,32 @@ use std::borrow::Cow;
 use std::convert::TryFrom;
 use std::str::{self, FromStr};
 
+use crate::config::{CronScheduleParts, DayOfWeekNumbering};
 use crate::error::{Error, ErrorKind};
 use crate::ordinal::*;
 use crate::schedule::{Schedule, ScheduleFields};
 use crate::specifier::*;
 use crate::time_unit::*;
+use crate::ScheduleConfig;
 
 impl TryFrom<Cow<'_, str>> for Schedule {
     type Error = Error;
 
     fn try_from(expression: Cow<'_, str>) -> Result<Self, Self::Error> {
-        match schedule.parse(&expression) {
-            Ok(schedule_fields) => Ok(Schedule::new(expression.into_owned(), schedule_fields)), // Extract from winnow tuple
-            Err(parse_error) => Err(ErrorKind::Expression(format!("{parse_error}")).into()),
+        Self::from_str_with_config(expression.as_ref(), ScheduleConfig::default())
+    }
+}
+
+impl Schedule {
+    /// Parse a cron expression using the supplied [ScheduleConfig].
+    pub fn from_str_with_config(expression: &str, config: ScheduleConfig) -> Result<Self, Error> {
+        match schedule_with_config(expression, config) {
+            Ok(schedule_fields) => Ok(Schedule::new(
+                expression.to_owned(),
+                schedule_fields,
+                config,
+            )),
+            Err(parse_error) => Err(ErrorKind::Expression(parse_error.to_string()).into()),
         }
     }
 }
@@ -45,6 +58,10 @@ impl FromStr for Schedule {
     fn from_str(expression: &str) -> Result<Self, Self::Err> {
         Self::try_from(Cow::Borrowed(expression))
     }
+}
+
+fn parse_with_defaults(i: &mut &str) -> winnow::Result<ScheduleFields> {
+    schedule.parse_next(i)
 }
 
 #[derive(Debug, PartialEq)]
@@ -295,6 +312,230 @@ fn longhand(i: &mut &str) -> winnow::Result<ScheduleFields> {
 
 fn schedule(i: &mut &str) -> winnow::Result<ScheduleFields> {
     alt((shorthand, longhand)).parse_next(i)
+}
+
+fn parse_field_token(token: &str) -> Result<Field, String> {
+    terminated(field, eof)
+        .parse(token)
+        .map_err(|parse_error| format!("{parse_error}"))
+}
+
+fn parse_field_with_any_token(token: &str) -> Result<Field, String> {
+    terminated(field_with_any, eof)
+        .parse(token)
+        .map_err(|parse_error| format!("{parse_error}"))
+}
+
+fn normalize_day_of_week_ordinal(
+    ordinal: Ordinal,
+    numbering: DayOfWeekNumbering,
+) -> Result<Ordinal, Error> {
+    match numbering {
+        DayOfWeekNumbering::OneToSeven => DaysOfWeek::validate_ordinal(ordinal),
+        DayOfWeekNumbering::ZeroToSix => match ordinal {
+            0..=6 => Ok(ordinal + 1),
+            _ => Err(ErrorKind::Expression(format!(
+                "Days of Week must be less than 7. ('{}' specified.)",
+                ordinal
+            ))
+            .into()),
+        },
+    }
+}
+
+fn normalize_day_of_week_specifier(
+    specifier: Specifier,
+    numbering: DayOfWeekNumbering,
+) -> Result<Specifier, Error> {
+    match specifier {
+        Specifier::All => Ok(Specifier::All),
+        Specifier::Point(ordinal) => Ok(Specifier::Point(normalize_day_of_week_ordinal(
+            ordinal, numbering,
+        )?)),
+        Specifier::Range(start, end) => Ok(Specifier::Range(
+            normalize_day_of_week_ordinal(start, numbering)?,
+            normalize_day_of_week_ordinal(end, numbering)?,
+        )),
+        Specifier::NamedRange(start, end) => Ok(Specifier::NamedRange(start, end)),
+    }
+}
+
+fn normalize_day_of_week_field(
+    field: Field,
+    numbering: DayOfWeekNumbering,
+) -> Result<Field, Error> {
+    let specifiers = field
+        .specifiers
+        .into_iter()
+        .map(|root_specifier| {
+            let specifier = match root_specifier {
+                RootSpecifier::Specifier(specifier) => {
+                    RootSpecifier::Specifier(normalize_day_of_week_specifier(specifier, numbering)?)
+                }
+                RootSpecifier::Period(specifier, step) => RootSpecifier::Period(
+                    normalize_day_of_week_specifier(specifier, numbering)?,
+                    step,
+                ),
+                RootSpecifier::NamedPoint(name) => RootSpecifier::NamedPoint(name),
+            };
+            Ok(specifier)
+        })
+        .collect::<Result<Vec<_>, Error>>()?;
+    Ok(Field { specifiers })
+}
+
+fn build_schedule_fields_from_six_part_tokens(
+    tokens: &[&str],
+    config: ScheduleConfig,
+) -> Result<ScheduleFields, String> {
+    let parse_years = |year_token: Option<&str>| -> Result<Years, String> {
+        match year_token {
+            Some(token) => Years::from_field(parse_field_token(token)?)
+                .map_err(|parse_error| format!("{parse_error}")),
+            None => Ok(Years::all()),
+        }
+    };
+
+    let parse_days_of_week = |token: &str| -> Result<DaysOfWeek, String> {
+        let field = parse_field_with_any_token(token).and_then(|f| {
+            normalize_day_of_week_field(f, config.day_of_week_numbering).map_err(|e| format!("{e}"))
+        })?;
+        DaysOfWeek::from_field(field).map_err(|parse_error| format!("{parse_error}"))
+    };
+
+    let (seconds, minutes, hours, days_of_month, months, days_of_week, years) = match tokens {
+        [seconds, minutes, hours, days_of_month, months, days_of_week] => (
+            Seconds::from_field(parse_field_token(seconds)?).map_err(|e| e.to_string())?,
+            Minutes::from_field(parse_field_token(minutes)?).map_err(|e| e.to_string())?,
+            Hours::from_field(parse_field_token(hours)?).map_err(|e| e.to_string())?,
+            DaysOfMonth::from_field(parse_field_with_any_token(days_of_month)?)
+                .map_err(|e| e.to_string())?,
+            Months::from_field(parse_field_token(months)?).map_err(|e| e.to_string())?,
+            parse_days_of_week(days_of_week)?,
+            Years::all(),
+        ),
+        [seconds, minutes, hours, days_of_month, months, days_of_week, year] => (
+            Seconds::from_field(parse_field_token(seconds)?).map_err(|e| e.to_string())?,
+            Minutes::from_field(parse_field_token(minutes)?).map_err(|e| e.to_string())?,
+            Hours::from_field(parse_field_token(hours)?).map_err(|e| e.to_string())?,
+            DaysOfMonth::from_field(parse_field_with_any_token(days_of_month)?)
+                .map_err(|e| e.to_string())?,
+            Months::from_field(parse_field_token(months)?).map_err(|e| e.to_string())?,
+            parse_days_of_week(days_of_week)?,
+            parse_years(Some(year))?,
+        ),
+        _ => return Err("a valid cron expression".to_owned()),
+    };
+
+    Ok(ScheduleFields::new(
+        seconds,
+        minutes,
+        hours,
+        days_of_month,
+        months,
+        days_of_week,
+        years,
+    ))
+}
+
+fn build_schedule_fields_from_five_part_tokens(
+    tokens: &[&str],
+    config: ScheduleConfig,
+) -> Result<ScheduleFields, String> {
+    let parse_years = |year_token: Option<&str>| -> Result<Years, String> {
+        match year_token {
+            Some(token) => Years::from_field(parse_field_token(token)?)
+                .map_err(|parse_error| format!("{parse_error}")),
+            None => Ok(Years::all()),
+        }
+    };
+
+    let parse_days_of_week = |token: &str| -> Result<DaysOfWeek, String> {
+        let field = parse_field_with_any_token(token).and_then(|f| {
+            normalize_day_of_week_field(f, config.day_of_week_numbering).map_err(|e| format!("{e}"))
+        })?;
+        DaysOfWeek::from_field(field).map_err(|parse_error| format!("{parse_error}"))
+    };
+
+    let (minutes, hours, days_of_month, months, days_of_week, years) = match tokens {
+        [minutes, hours, days_of_month, months, days_of_week] => (
+            Minutes::from_field(parse_field_token(minutes)?).map_err(|e| e.to_string())?,
+            Hours::from_field(parse_field_token(hours)?).map_err(|e| e.to_string())?,
+            DaysOfMonth::from_field(parse_field_with_any_token(days_of_month)?)
+                .map_err(|e| e.to_string())?,
+            Months::from_field(parse_field_token(months)?).map_err(|e| e.to_string())?,
+            parse_days_of_week(days_of_week)?,
+            Years::all(),
+        ),
+        [minutes, hours, days_of_month, months, days_of_week, year] => (
+            Minutes::from_field(parse_field_token(minutes)?).map_err(|e| e.to_string())?,
+            Hours::from_field(parse_field_token(hours)?).map_err(|e| e.to_string())?,
+            DaysOfMonth::from_field(parse_field_with_any_token(days_of_month)?)
+                .map_err(|e| e.to_string())?,
+            Months::from_field(parse_field_token(months)?).map_err(|e| e.to_string())?,
+            parse_days_of_week(days_of_week)?,
+            parse_years(Some(year))?,
+        ),
+        _ => return Err("a valid cron expression".to_owned()),
+    };
+
+    Ok(ScheduleFields::new(
+        Seconds::from_ordinal(0),
+        minutes,
+        hours,
+        days_of_month,
+        months,
+        days_of_week,
+        years,
+    ))
+}
+
+fn schedule_with_config(
+    expression: &str,
+    config: ScheduleConfig,
+) -> Result<ScheduleFields, String> {
+    if config == ScheduleConfig::default() {
+        return parse_with_defaults
+            .parse(expression)
+            .map_err(|parse_error| format!("{parse_error}"));
+    }
+
+    if let Ok(fields) = terminated(shorthand, eof).parse(expression) {
+        return Ok(fields);
+    }
+
+    let tokens = expression.split_whitespace().collect::<Vec<_>>();
+    if tokens.is_empty() {
+        return Err("a valid cron expression".to_owned());
+    }
+
+    let parse_six = || match tokens.len() {
+        6 | 7 => build_schedule_fields_from_six_part_tokens(tokens.as_slice(), config),
+        _ => Err("a valid cron expression".to_owned()),
+    };
+
+    let parse_five = || match tokens.len() {
+        5 | 6 => build_schedule_fields_from_five_part_tokens(tokens.as_slice(), config),
+        _ => Err("a valid cron expression".to_owned()),
+    };
+
+    match config.cron_schedule_parts {
+        CronScheduleParts::Six => parse_six(),
+        CronScheduleParts::Five => parse_five(),
+        CronScheduleParts::Both => {
+            if tokens.len() == 6 {
+                parse_six().or_else(|_| parse_five())
+            } else if matches!(tokens.len(), 7 | 5) {
+                if tokens.len() == 7 {
+                    parse_six()
+                } else {
+                    parse_five()
+                }
+            } else {
+                Err("a valid cron expression".to_owned())
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -114,6 +114,14 @@ fn point(i: &mut &str) -> winnow::Result<Specifier> {
     ordinal.map(Specifier::Point).parse_next(i)
 }
 
+fn range_endpoint(i: &mut &str) -> winnow::Result<RangeEndpoint> {
+    alt((
+        ordinal.map(RangeEndpoint::Ordinal),
+        name.map(RangeEndpoint::Name),
+    ))
+    .parse_next(i)
+}
+
 fn named_point(i: &mut &str) -> winnow::Result<RootSpecifier> {
     name.map(RootSpecifier::NamedPoint).parse_next(i)
 }
@@ -131,14 +139,15 @@ fn period_with_any(i: &mut &str) -> winnow::Result<RootSpecifier> {
 }
 
 fn range(i: &mut &str) -> winnow::Result<Specifier> {
-    separated_pair(ordinal, "-", ordinal)
+    separated_pair(range_endpoint, "-", range_endpoint)
         .map(|(start, end)| Specifier::Range(start, end))
         .parse_next(i)
 }
 
+#[cfg(test)]
 fn named_range(i: &mut &str) -> winnow::Result<Specifier> {
     separated_pair(name, "-", name)
-        .map(|(start, end)| Specifier::NamedRange(start, end))
+        .map(|(start, end)| Specifier::Range(RangeEndpoint::Name(start), RangeEndpoint::Name(end)))
         .parse_next(i)
 }
 
@@ -151,7 +160,7 @@ fn any(i: &mut &str) -> winnow::Result<Specifier> {
 }
 
 fn specifier(i: &mut &str) -> winnow::Result<Specifier> {
-    alt((all, range, point, named_range)).parse_next(i)
+    alt((all, range, point)).parse_next(i)
 }
 
 fn specifier_with_any(i: &mut &str) -> winnow::Result<Specifier> {
@@ -326,62 +335,143 @@ fn parse_field_with_any_token(token: &str) -> Result<Field, String> {
         .map_err(|parse_error| format!("{parse_error}"))
 }
 
-fn normalize_day_of_week_ordinal(
-    ordinal: Ordinal,
-    numbering: DayOfWeekNumbering,
-) -> Result<Ordinal, Error> {
-    match numbering {
-        DayOfWeekNumbering::OneToSeven => DaysOfWeek::validate_ordinal(ordinal),
-        DayOfWeekNumbering::ZeroToSix => match ordinal {
-            0..=6 => Ok(ordinal + 1),
-            _ => Err(ErrorKind::Expression(format!(
-                "Days of Week must be less than 7. ('{}' specified.)",
-                ordinal
-            ))
-            .into()),
-        },
+fn from_field_with_options<T>(field: Field, wraparound_ranges: bool) -> Result<T, Error>
+where
+    T: TimeUnitField,
+{
+    if field.specifiers.len() == 1
+        && field.specifiers.first().unwrap() == &RootSpecifier::from(Specifier::All)
+    {
+        return Ok(T::all());
+    }
+
+    let mut ordinals = OrdinalSet::new();
+    for specifier in field.specifiers {
+        let specifier_ordinals =
+            T::ordinals_from_root_specifier_with_options(&specifier, wraparound_ranges)?;
+        for ordinal in specifier_ordinals {
+            ordinals.insert(T::validate_ordinal(ordinal)?);
+        }
+    }
+    Ok(T::from_ordinal_set(ordinals))
+}
+
+fn zero_indexed_day_of_week_from_numeric(ordinal: Ordinal) -> Result<Ordinal, Error> {
+    match ordinal {
+        0 | 7 => Ok(0),
+        1..=6 => Ok(ordinal),
+        _ => Err(ErrorKind::Expression(format!(
+            "Days of Week must be between 0 and 7. ('{}' specified.)",
+            ordinal
+        ))
+        .into()),
     }
 }
 
-fn normalize_day_of_week_specifier(
-    specifier: Specifier,
-    numbering: DayOfWeekNumbering,
-) -> Result<Specifier, Error> {
+fn zero_indexed_day_of_week_to_internal_ordinal(ordinal: Ordinal) -> Ordinal {
+    debug_assert!(ordinal <= 6);
+    ordinal + 1
+}
+
+fn zero_indexed_day_of_week_from_name(name: &str) -> Result<Ordinal, Error> {
+    let internal_ordinal = DaysOfWeek::ordinal_from_name(name)?;
+    debug_assert!((1..=7).contains(&internal_ordinal));
+    // The shared day-name map uses the crate's Sunday=1 internal ordinals.
+    // Vixie range expansion uses Sunday=0, so decrement named weekdays into that space.
+    Ok(internal_ordinal - 1)
+}
+
+fn zero_indexed_day_of_week_from_endpoint(endpoint: &RangeEndpoint) -> Result<Ordinal, Error> {
+    match endpoint {
+        RangeEndpoint::Ordinal(ordinal) => zero_indexed_day_of_week_from_numeric(*ordinal),
+        RangeEndpoint::Name(name) => zero_indexed_day_of_week_from_name(name),
+    }
+}
+
+fn zero_indexed_day_of_week_values_from_specifier(
+    specifier: &Specifier,
+    wraparound_ranges: bool,
+) -> Result<Vec<Ordinal>, Error> {
     match specifier {
-        Specifier::All => Ok(Specifier::All),
-        Specifier::Point(ordinal) => Ok(Specifier::Point(normalize_day_of_week_ordinal(
-            ordinal, numbering,
-        )?)),
-        Specifier::Range(start, end) => Ok(Specifier::Range(
-            normalize_day_of_week_ordinal(start, numbering)?,
-            normalize_day_of_week_ordinal(end, numbering)?,
-        )),
-        Specifier::NamedRange(start, end) => Ok(Specifier::NamedRange(start, end)),
+        Specifier::All => Ok((0..=6).collect()),
+        Specifier::Point(ordinal) => Ok(vec![zero_indexed_day_of_week_from_numeric(*ordinal)?]),
+        Specifier::Range(start, end) => {
+            let start_ordinal = zero_indexed_day_of_week_from_endpoint(start)?;
+            let end_ordinal = zero_indexed_day_of_week_from_endpoint(end)?;
+            ordinal_range_values(start_ordinal, end_ordinal, 0, 6, wraparound_ranges).ok_or_else(
+                || {
+                    ErrorKind::Expression(format!(
+                        "Invalid range for Days of Week: {}-{}",
+                        start, end
+                    ))
+                    .into()
+                },
+            )
+        }
     }
 }
 
-fn normalize_day_of_week_field(
-    field: Field,
-    numbering: DayOfWeekNumbering,
-) -> Result<Field, Error> {
-    let specifiers = field
-        .specifiers
-        .into_iter()
-        .map(|root_specifier| {
-            let specifier = match root_specifier {
-                RootSpecifier::Specifier(specifier) => {
-                    RootSpecifier::Specifier(normalize_day_of_week_specifier(specifier, numbering)?)
-                }
-                RootSpecifier::Period(specifier, step) => RootSpecifier::Period(
-                    normalize_day_of_week_specifier(specifier, numbering)?,
+fn zero_indexed_day_of_week_internal_ordinals_from_root_specifier(
+    root_specifier: &RootSpecifier,
+    wraparound_ranges: bool,
+) -> Result<OrdinalSet, Error> {
+    let ordinals = match root_specifier {
+        RootSpecifier::Specifier(specifier) => {
+            zero_indexed_day_of_week_values_from_specifier(specifier, wraparound_ranges)?
+        }
+        RootSpecifier::Period(_, 0) => Err(ErrorKind::Expression(
+            "range step cannot be zero".to_string(),
+        ))?,
+        RootSpecifier::Period(start, step) => {
+            if *step < 1 || *step > 7 {
+                return Err(ErrorKind::Expression(format!(
+                    "Days of Week must be between 1 and 7. ('{}' specified.)",
                     step,
-                ),
-                RootSpecifier::NamedPoint(name) => RootSpecifier::NamedPoint(name),
+                ))
+                .into());
+            }
+
+            let base_values = match start {
+                Specifier::Point(start) => {
+                    let start = zero_indexed_day_of_week_from_numeric(*start)?;
+                    (start..=6).collect()
+                }
+                specifier => {
+                    zero_indexed_day_of_week_values_from_specifier(specifier, wraparound_ranges)?
+                }
             };
-            Ok(specifier)
-        })
-        .collect::<Result<Vec<_>, Error>>()?;
-    Ok(Field { specifiers })
+            base_values.into_iter().step_by(*step as usize).collect()
+        }
+        RootSpecifier::NamedPoint(name) => vec![zero_indexed_day_of_week_from_name(name)?],
+    };
+
+    Ok(ordinals
+        .into_iter()
+        .map(zero_indexed_day_of_week_to_internal_ordinal)
+        .collect())
+}
+
+fn days_of_week_from_field(field: Field, config: ScheduleConfig) -> Result<DaysOfWeek, Error> {
+    if field.specifiers.len() == 1
+        && field.specifiers.first().unwrap() == &RootSpecifier::from(Specifier::All)
+    {
+        return Ok(DaysOfWeek::all());
+    }
+
+    if config.day_of_week_numbering == DayOfWeekNumbering::OneIndexed {
+        return from_field_with_options(field, config.wraparound_ranges);
+    }
+
+    let mut ordinals = OrdinalSet::new();
+    for specifier in field.specifiers {
+        for ordinal in zero_indexed_day_of_week_internal_ordinals_from_root_specifier(
+            &specifier,
+            config.wraparound_ranges,
+        )? {
+            ordinals.insert(DaysOfWeek::validate_ordinal(ordinal)?);
+        }
+    }
+    Ok(DaysOfWeek::from_ordinal_set(ordinals))
 }
 
 fn build_schedule_fields_from_six_part_tokens(
@@ -390,37 +480,51 @@ fn build_schedule_fields_from_six_part_tokens(
 ) -> Result<ScheduleFields, String> {
     let parse_years = |year_token: Option<&str>| -> Result<Years, String> {
         match year_token {
-            Some(token) => Years::from_field(parse_field_token(token)?)
-                .map_err(|parse_error| format!("{parse_error}")),
+            Some(token) => {
+                from_field_with_options(parse_field_token(token)?, config.wraparound_ranges)
+                    .map_err(|parse_error| format!("{parse_error}"))
+            }
             None => Ok(Years::all()),
         }
     };
 
     let parse_days_of_week = |token: &str| -> Result<DaysOfWeek, String> {
-        let field = parse_field_with_any_token(token).and_then(|f| {
-            normalize_day_of_week_field(f, config.day_of_week_numbering).map_err(|e| format!("{e}"))
-        })?;
-        DaysOfWeek::from_field(field).map_err(|parse_error| format!("{parse_error}"))
+        days_of_week_from_field(parse_field_with_any_token(token)?, config)
+            .map_err(|parse_error| format!("{parse_error}"))
     };
 
     let (seconds, minutes, hours, days_of_month, months, days_of_week, years) = match tokens {
         [seconds, minutes, hours, days_of_month, months, days_of_week] => (
-            Seconds::from_field(parse_field_token(seconds)?).map_err(|e| e.to_string())?,
-            Minutes::from_field(parse_field_token(minutes)?).map_err(|e| e.to_string())?,
-            Hours::from_field(parse_field_token(hours)?).map_err(|e| e.to_string())?,
-            DaysOfMonth::from_field(parse_field_with_any_token(days_of_month)?)
+            from_field_with_options(parse_field_token(seconds)?, config.wraparound_ranges)
                 .map_err(|e| e.to_string())?,
-            Months::from_field(parse_field_token(months)?).map_err(|e| e.to_string())?,
+            from_field_with_options(parse_field_token(minutes)?, config.wraparound_ranges)
+                .map_err(|e| e.to_string())?,
+            from_field_with_options(parse_field_token(hours)?, config.wraparound_ranges)
+                .map_err(|e| e.to_string())?,
+            from_field_with_options(
+                parse_field_with_any_token(days_of_month)?,
+                config.wraparound_ranges,
+            )
+            .map_err(|e| e.to_string())?,
+            from_field_with_options(parse_field_token(months)?, config.wraparound_ranges)
+                .map_err(|e| e.to_string())?,
             parse_days_of_week(days_of_week)?,
             Years::all(),
         ),
         [seconds, minutes, hours, days_of_month, months, days_of_week, year] => (
-            Seconds::from_field(parse_field_token(seconds)?).map_err(|e| e.to_string())?,
-            Minutes::from_field(parse_field_token(minutes)?).map_err(|e| e.to_string())?,
-            Hours::from_field(parse_field_token(hours)?).map_err(|e| e.to_string())?,
-            DaysOfMonth::from_field(parse_field_with_any_token(days_of_month)?)
+            from_field_with_options(parse_field_token(seconds)?, config.wraparound_ranges)
                 .map_err(|e| e.to_string())?,
-            Months::from_field(parse_field_token(months)?).map_err(|e| e.to_string())?,
+            from_field_with_options(parse_field_token(minutes)?, config.wraparound_ranges)
+                .map_err(|e| e.to_string())?,
+            from_field_with_options(parse_field_token(hours)?, config.wraparound_ranges)
+                .map_err(|e| e.to_string())?,
+            from_field_with_options(
+                parse_field_with_any_token(days_of_month)?,
+                config.wraparound_ranges,
+            )
+            .map_err(|e| e.to_string())?,
+            from_field_with_options(parse_field_token(months)?, config.wraparound_ranges)
+                .map_err(|e| e.to_string())?,
             parse_days_of_week(days_of_week)?,
             parse_years(Some(year))?,
         ),
@@ -444,35 +548,47 @@ fn build_schedule_fields_from_five_part_tokens(
 ) -> Result<ScheduleFields, String> {
     let parse_years = |year_token: Option<&str>| -> Result<Years, String> {
         match year_token {
-            Some(token) => Years::from_field(parse_field_token(token)?)
-                .map_err(|parse_error| format!("{parse_error}")),
+            Some(token) => {
+                from_field_with_options(parse_field_token(token)?, config.wraparound_ranges)
+                    .map_err(|parse_error| format!("{parse_error}"))
+            }
             None => Ok(Years::all()),
         }
     };
 
     let parse_days_of_week = |token: &str| -> Result<DaysOfWeek, String> {
-        let field = parse_field_with_any_token(token).and_then(|f| {
-            normalize_day_of_week_field(f, config.day_of_week_numbering).map_err(|e| format!("{e}"))
-        })?;
-        DaysOfWeek::from_field(field).map_err(|parse_error| format!("{parse_error}"))
+        days_of_week_from_field(parse_field_with_any_token(token)?, config)
+            .map_err(|parse_error| format!("{parse_error}"))
     };
 
     let (minutes, hours, days_of_month, months, days_of_week, years) = match tokens {
         [minutes, hours, days_of_month, months, days_of_week] => (
-            Minutes::from_field(parse_field_token(minutes)?).map_err(|e| e.to_string())?,
-            Hours::from_field(parse_field_token(hours)?).map_err(|e| e.to_string())?,
-            DaysOfMonth::from_field(parse_field_with_any_token(days_of_month)?)
+            from_field_with_options(parse_field_token(minutes)?, config.wraparound_ranges)
                 .map_err(|e| e.to_string())?,
-            Months::from_field(parse_field_token(months)?).map_err(|e| e.to_string())?,
+            from_field_with_options(parse_field_token(hours)?, config.wraparound_ranges)
+                .map_err(|e| e.to_string())?,
+            from_field_with_options(
+                parse_field_with_any_token(days_of_month)?,
+                config.wraparound_ranges,
+            )
+            .map_err(|e| e.to_string())?,
+            from_field_with_options(parse_field_token(months)?, config.wraparound_ranges)
+                .map_err(|e| e.to_string())?,
             parse_days_of_week(days_of_week)?,
             Years::all(),
         ),
         [minutes, hours, days_of_month, months, days_of_week, year] => (
-            Minutes::from_field(parse_field_token(minutes)?).map_err(|e| e.to_string())?,
-            Hours::from_field(parse_field_token(hours)?).map_err(|e| e.to_string())?,
-            DaysOfMonth::from_field(parse_field_with_any_token(days_of_month)?)
+            from_field_with_options(parse_field_token(minutes)?, config.wraparound_ranges)
                 .map_err(|e| e.to_string())?,
-            Months::from_field(parse_field_token(months)?).map_err(|e| e.to_string())?,
+            from_field_with_options(parse_field_token(hours)?, config.wraparound_ranges)
+                .map_err(|e| e.to_string())?,
+            from_field_with_options(
+                parse_field_with_any_token(days_of_month)?,
+                config.wraparound_ranges,
+            )
+            .map_err(|e| e.to_string())?,
+            from_field_with_options(parse_field_token(months)?, config.wraparound_ranges)
+                .map_err(|e| e.to_string())?,
             parse_days_of_week(days_of_week)?,
             parse_years(Some(year))?,
         ),

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -1,5 +1,5 @@
 use winnow::ascii::{alpha1, digit1, multispace0};
-use winnow::combinator::{alt, delimited, eof, opt, separated, separated_pair, terminated};
+use winnow::combinator::{alt, delimited, eof, separated, separated_pair, terminated};
 use winnow::prelude::*;
 
 use std::borrow::Cow;
@@ -60,42 +60,9 @@ impl FromStr for Schedule {
     }
 }
 
-fn parse_with_defaults(i: &mut &str) -> winnow::Result<ScheduleFields> {
-    schedule.parse_next(i)
-}
-
 #[derive(Debug, PartialEq)]
 pub struct Field {
     pub specifiers: Vec<RootSpecifier>, // TODO: expose iterator?
-}
-
-trait FromField
-where
-    Self: Sized,
-{
-    //TODO: Replace with std::convert::TryFrom when stable
-    fn from_field(field: Field) -> Result<Self, Error>;
-}
-
-impl<T> FromField for T
-where
-    T: TimeUnitField,
-{
-    fn from_field(field: Field) -> Result<T, Error> {
-        if field.specifiers.len() == 1
-            && field.specifiers.first().unwrap() == &RootSpecifier::from(Specifier::All)
-        {
-            return Ok(T::all());
-        }
-        let mut ordinals = OrdinalSet::new();
-        for specifier in field.specifiers {
-            let specifier_ordinals: OrdinalSet = T::ordinals_from_root_specifier(&specifier)?;
-            for ordinal in specifier_ordinals {
-                ordinals.insert(T::validate_ordinal(ordinal)?);
-            }
-        }
-        Ok(T::from_ordinal_set(ordinals))
-    }
 }
 
 fn ordinal(i: &mut &str) -> winnow::Result<u32> {
@@ -283,46 +250,6 @@ fn shorthand(i: &mut &str) -> winnow::Result<ScheduleFields> {
     delimited(multispace0, keywords, multispace0).parse_next(i)
 }
 
-fn longhand(i: &mut &str) -> winnow::Result<ScheduleFields> {
-    let seconds = field.try_map(Seconds::from_field);
-    let minutes = field.try_map(Minutes::from_field);
-    let hours = field.try_map(Hours::from_field);
-    let days_of_month = field_with_any.try_map(DaysOfMonth::from_field);
-    let months = field.try_map(Months::from_field);
-    let days_of_week = field_with_any.try_map(DaysOfWeek::from_field);
-    let years = opt(field.try_map(Years::from_field));
-    let fields = (
-        seconds,
-        minutes,
-        hours,
-        days_of_month,
-        months,
-        days_of_week,
-        years,
-    );
-
-    terminated(fields, eof)
-        .map(
-            |(seconds, minutes, hours, days_of_month, months, days_of_week, years)| {
-                let years = years.unwrap_or_else(Years::all);
-                ScheduleFields::new(
-                    seconds,
-                    minutes,
-                    hours,
-                    days_of_month,
-                    months,
-                    days_of_week,
-                    years,
-                )
-            },
-        )
-        .parse_next(i)
-}
-
-fn schedule(i: &mut &str) -> winnow::Result<ScheduleFields> {
-    alt((shorthand, longhand)).parse_next(i)
-}
-
 fn parse_field_token(token: &str) -> Result<Field, String> {
     terminated(field, eof)
         .parse(token)
@@ -499,26 +426,20 @@ fn days_of_week_from_field(field: Field, config: ScheduleConfig) -> Result<DaysO
     Ok(DaysOfWeek::from_ordinal_set(ordinals))
 }
 
+fn years_from_field(field: Field, config: ScheduleConfig) -> Result<Years, Error> {
+    Years::from_root_specifiers(field.specifiers, config.wraparound_ranges)
+}
+
 fn build_schedule_fields_from_six_part_tokens(
     tokens: &[&str],
     config: ScheduleConfig,
 ) -> Result<ScheduleFields, String> {
-    let parse_years = |year_token: Option<&str>| -> Result<Years, String> {
-        match year_token {
-            Some(token) => {
-                from_field_with_options(parse_field_token(token)?, config.wraparound_ranges)
-                    .map_err(|parse_error| format!("{parse_error}"))
-            }
-            None => Ok(Years::all()),
-        }
-    };
-
     let parse_days_of_week = |token: &str| -> Result<DaysOfWeek, String> {
         days_of_week_from_field(parse_field_with_any_token(token)?, config)
             .map_err(|parse_error| format!("{parse_error}"))
     };
 
-    let (seconds, minutes, hours, days_of_month, months, days_of_week, years) = match tokens {
+    let (seconds, minutes, hours, days_of_month, months, days_of_week) = match tokens {
         [seconds, minutes, hours, days_of_month, months, days_of_week] => (
             from_field_with_options(parse_field_token(seconds)?, config.wraparound_ranges)
                 .map_err(|e| e.to_string())?,
@@ -534,24 +455,6 @@ fn build_schedule_fields_from_six_part_tokens(
             from_field_with_options(parse_field_token(months)?, config.wraparound_ranges)
                 .map_err(|e| e.to_string())?,
             parse_days_of_week(days_of_week)?,
-            Years::all(),
-        ),
-        [seconds, minutes, hours, days_of_month, months, days_of_week, year] => (
-            from_field_with_options(parse_field_token(seconds)?, config.wraparound_ranges)
-                .map_err(|e| e.to_string())?,
-            from_field_with_options(parse_field_token(minutes)?, config.wraparound_ranges)
-                .map_err(|e| e.to_string())?,
-            from_field_with_options(parse_field_token(hours)?, config.wraparound_ranges)
-                .map_err(|e| e.to_string())?,
-            from_field_with_options(
-                parse_field_with_any_token(days_of_month)?,
-                config.wraparound_ranges,
-            )
-            .map_err(|e| e.to_string())?,
-            from_field_with_options(parse_field_token(months)?, config.wraparound_ranges)
-                .map_err(|e| e.to_string())?,
-            parse_days_of_week(days_of_week)?,
-            parse_years(Some(year))?,
         ),
         _ => return Err("a valid cron expression".to_owned()),
     };
@@ -563,7 +466,36 @@ fn build_schedule_fields_from_six_part_tokens(
         days_of_month,
         months,
         days_of_week,
-        years,
+        Years::all(),
+    ))
+}
+
+fn build_schedule_fields_from_seven_part_tokens(
+    tokens: &[&str],
+    config: ScheduleConfig,
+) -> Result<ScheduleFields, String> {
+    let [seconds, minutes, hours, days_of_month, months, days_of_week, years] = tokens else {
+        return Err("a valid cron expression".to_owned());
+    };
+
+    Ok(ScheduleFields::new(
+        from_field_with_options(parse_field_token(seconds)?, config.wraparound_ranges)
+            .map_err(|e| e.to_string())?,
+        from_field_with_options(parse_field_token(minutes)?, config.wraparound_ranges)
+            .map_err(|e| e.to_string())?,
+        from_field_with_options(parse_field_token(hours)?, config.wraparound_ranges)
+            .map_err(|e| e.to_string())?,
+        from_field_with_options(
+            parse_field_with_any_token(days_of_month)?,
+            config.wraparound_ranges,
+        )
+        .map_err(|e| e.to_string())?,
+        from_field_with_options(parse_field_token(months)?, config.wraparound_ranges)
+            .map_err(|e| e.to_string())?,
+        days_of_week_from_field(parse_field_with_any_token(days_of_week)?, config)
+            .map_err(|parse_error| format!("{parse_error}"))?,
+        years_from_field(parse_field_token(years)?, config)
+            .map_err(|parse_error| format!("{parse_error}"))?,
     ))
 }
 
@@ -571,22 +503,12 @@ fn build_schedule_fields_from_five_part_tokens(
     tokens: &[&str],
     config: ScheduleConfig,
 ) -> Result<ScheduleFields, String> {
-    let parse_years = |year_token: Option<&str>| -> Result<Years, String> {
-        match year_token {
-            Some(token) => {
-                from_field_with_options(parse_field_token(token)?, config.wraparound_ranges)
-                    .map_err(|parse_error| format!("{parse_error}"))
-            }
-            None => Ok(Years::all()),
-        }
-    };
-
     let parse_days_of_week = |token: &str| -> Result<DaysOfWeek, String> {
         days_of_week_from_field(parse_field_with_any_token(token)?, config)
             .map_err(|parse_error| format!("{parse_error}"))
     };
 
-    let (minutes, hours, days_of_month, months, days_of_week, years) = match tokens {
+    let (minutes, hours, days_of_month, months, days_of_week) = match tokens {
         [minutes, hours, days_of_month, months, days_of_week] => (
             from_field_with_options(parse_field_token(minutes)?, config.wraparound_ranges)
                 .map_err(|e| e.to_string())?,
@@ -600,22 +522,6 @@ fn build_schedule_fields_from_five_part_tokens(
             from_field_with_options(parse_field_token(months)?, config.wraparound_ranges)
                 .map_err(|e| e.to_string())?,
             parse_days_of_week(days_of_week)?,
-            Years::all(),
-        ),
-        [minutes, hours, days_of_month, months, days_of_week, year] => (
-            from_field_with_options(parse_field_token(minutes)?, config.wraparound_ranges)
-                .map_err(|e| e.to_string())?,
-            from_field_with_options(parse_field_token(hours)?, config.wraparound_ranges)
-                .map_err(|e| e.to_string())?,
-            from_field_with_options(
-                parse_field_with_any_token(days_of_month)?,
-                config.wraparound_ranges,
-            )
-            .map_err(|e| e.to_string())?,
-            from_field_with_options(parse_field_token(months)?, config.wraparound_ranges)
-                .map_err(|e| e.to_string())?,
-            parse_days_of_week(days_of_week)?,
-            parse_years(Some(year))?,
         ),
         _ => return Err("a valid cron expression".to_owned()),
     };
@@ -627,7 +533,7 @@ fn build_schedule_fields_from_five_part_tokens(
         days_of_month,
         months,
         days_of_week,
-        years,
+        Years::all(),
     ))
 }
 
@@ -635,12 +541,6 @@ fn schedule_with_config(
     expression: &str,
     config: ScheduleConfig,
 ) -> Result<ScheduleFields, String> {
-    if config == ScheduleConfig::default() {
-        return parse_with_defaults
-            .parse(expression)
-            .map_err(|parse_error| format!("{parse_error}"));
-    }
-
     if let Ok(fields) = terminated(shorthand, eof).parse(expression) {
         return Ok(fields);
     }
@@ -650,38 +550,31 @@ fn schedule_with_config(
         return Err("a valid cron expression".to_owned());
     }
 
-    let parse_six = || match tokens.len() {
-        6 | 7 => build_schedule_fields_from_six_part_tokens(tokens.as_slice(), config),
-        _ => Err("a valid cron expression".to_owned()),
-    };
-
-    let parse_five = || match tokens.len() {
-        5 | 6 => build_schedule_fields_from_five_part_tokens(tokens.as_slice(), config),
-        _ => Err("a valid cron expression".to_owned()),
-    };
-
-    match config.cron_schedule_parts {
-        CronScheduleParts::Six => parse_six(),
-        CronScheduleParts::Five => parse_five(),
-        CronScheduleParts::Both => {
-            if tokens.len() == 6 {
-                parse_six().or_else(|_| parse_five())
-            } else if matches!(tokens.len(), 7 | 5) {
-                if tokens.len() == 7 {
-                    parse_six()
-                } else {
-                    parse_five()
-                }
-            } else {
-                Err("a valid cron expression".to_owned())
-            }
+    match (tokens.len(), config.cron_schedule_parts) {
+        (5, CronScheduleParts::Five | CronScheduleParts::FiveOrSix | CronScheduleParts::All) => {
+            build_schedule_fields_from_five_part_tokens(tokens.as_slice(), config)
         }
+        (
+            6,
+            CronScheduleParts::Six
+            | CronScheduleParts::FiveOrSix
+            | CronScheduleParts::SixOrSeven
+            | CronScheduleParts::All,
+        ) => build_schedule_fields_from_six_part_tokens(tokens.as_slice(), config),
+        (7, CronScheduleParts::Seven | CronScheduleParts::SixOrSeven | CronScheduleParts::All) => {
+            build_schedule_fields_from_seven_part_tokens(tokens.as_slice(), config)
+        }
+        _ => Err("a valid cron expression".to_owned()),
     }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
+
+    fn parse_schedule(expression: &str) -> Result<Schedule, Error> {
+        Schedule::from_str(expression)
+    }
 
     #[test]
     fn test_nom_valid_number() {
@@ -868,142 +761,142 @@ mod test {
     #[test]
     fn test_nom_valid_schedule() {
         let expression = "* * * * * *";
-        schedule.parse(expression).unwrap();
+        parse_schedule(expression).unwrap();
     }
 
     #[test]
     fn test_nom_invalid_schedule() {
         let expression = "* * * *";
-        assert!(schedule.parse(expression).is_err());
+        assert!(parse_schedule(expression).is_err());
     }
 
     #[test]
     fn test_nom_valid_seconds_list() {
         let expression = "0,20,40 * * * * *";
-        schedule.parse(expression).unwrap();
+        parse_schedule(expression).unwrap();
     }
 
     #[test]
     fn test_nom_valid_seconds_range() {
         let expression = "0-40 * * * * *";
-        schedule.parse(expression).unwrap();
+        parse_schedule(expression).unwrap();
     }
 
     #[test]
     fn test_nom_valid_seconds_mix() {
         let expression = "0-5,58 * * * * *";
-        schedule.parse(expression).unwrap();
+        parse_schedule(expression).unwrap();
     }
 
     #[test]
     fn test_nom_invalid_seconds_range() {
         let expression = "0-65 * * * * *";
-        assert!(schedule.parse(expression).is_err());
+        assert!(parse_schedule(expression).is_err());
     }
 
     #[test]
     fn test_nom_invalid_seconds_list() {
         let expression = "103,12 * * * * *";
-        assert!(schedule.parse(expression).is_err());
+        assert!(parse_schedule(expression).is_err());
     }
 
     #[test]
     fn test_nom_invalid_seconds_mix() {
         let expression = "0-5,102 * * * * *";
-        assert!(schedule.parse(expression).is_err());
+        assert!(parse_schedule(expression).is_err());
     }
 
     #[test]
     fn test_nom_valid_days_of_week_list() {
         let expression = "* * * * * MON,WED,FRI";
-        schedule.parse(expression).unwrap();
+        parse_schedule(expression).unwrap();
     }
 
     #[test]
     fn test_nom_invalid_days_of_week_list() {
         let expression = "* * * * * MON,TURTLE";
-        assert!(schedule.parse(expression).is_err());
+        assert!(parse_schedule(expression).is_err());
     }
 
     #[test]
     fn test_nom_valid_days_of_week_range() {
         let expression = "* * * * * MON-FRI";
-        schedule.parse(expression).unwrap();
+        parse_schedule(expression).unwrap();
     }
 
     #[test]
     fn test_nom_invalid_days_of_week_range() {
         let expression = "* * * * * BEAR-OWL";
-        assert!(schedule.parse(expression).is_err());
+        assert!(parse_schedule(expression).is_err());
     }
 
     #[test]
     fn test_nom_invalid_period_with_range_specifier() {
         let expression = "10-12/10-12 * * * * ?";
-        assert!(schedule.parse(expression).is_err());
+        assert!(parse_schedule(expression).is_err());
     }
 
     #[test]
     fn test_nom_valid_days_of_month_any() {
         let expression = "* * * ? * *";
-        schedule.parse(expression).unwrap();
+        parse_schedule(expression).unwrap();
     }
 
     #[test]
     fn test_nom_valid_days_of_week_any() {
         let expression = "* * * * * ?";
-        schedule.parse(expression).unwrap();
+        parse_schedule(expression).unwrap();
     }
 
     #[test]
     fn test_nom_valid_days_of_month_any_days_of_week_specific() {
         let expression = "* * * ? * Mon,Thu";
-        schedule.parse(expression).unwrap();
+        parse_schedule(expression).unwrap();
     }
 
     #[test]
     fn test_nom_valid_days_of_week_any_days_of_month_specific() {
         let expression = "* * * 1,2 * ?";
-        schedule.parse(expression).unwrap();
+        parse_schedule(expression).unwrap();
     }
 
     #[test]
     fn test_nom_valid_dom_and_dow_any() {
         let expression = "* * * ? * ?";
-        schedule.parse(expression).unwrap();
+        parse_schedule(expression).unwrap();
     }
 
     #[test]
     fn test_nom_invalid_other_fields_any() {
         let expression = "? * * * * *";
-        assert!(schedule.parse(expression).is_err());
+        assert!(parse_schedule(expression).is_err());
 
         let expression = "* ? * * * *";
-        assert!(schedule.parse(expression).is_err());
+        assert!(parse_schedule(expression).is_err());
 
         let expression = "* * ? * * *";
-        assert!(schedule.parse(expression).is_err());
+        assert!(parse_schedule(expression).is_err());
 
         let expression = "* * * * ? *";
-        assert!(schedule.parse(expression).is_err());
+        assert!(parse_schedule(expression).is_err());
     }
 
     #[test]
     fn test_nom_invalid_trailing_characters() {
         let expression = "* * * * * *foo *";
-        assert!(schedule.parse(expression).is_err());
+        assert!(parse_schedule(expression).is_err());
 
         let expression = "* * * * * * * foo";
-        assert!(schedule.parse(expression).is_err());
+        assert!(parse_schedule(expression).is_err());
     }
 
     /// Issue #86
     #[test]
     fn shorthand_must_match_whole_input() {
         let expression = "@dailyBla";
-        assert!(schedule.parse(expression).is_err());
+        assert!(parse_schedule(expression).is_err());
         let expression = " @dailyBla ";
-        assert!(schedule.parse(expression).is_err());
+        assert!(parse_schedule(expression).is_err());
     }
 
     #[test]
@@ -1047,9 +940,8 @@ mod test {
             "* * * */32 * *",
             "* * * * */13 *",
             "1,2,3/60 * * * * *",
-            "0 0 0 1 1 ? 2020-2040/2200",
         ] {
-            assert!(schedule.parse(invalid_expression).is_err());
+            assert!(parse_schedule(invalid_expression).is_err());
         }
 
         for valid_expression in [
@@ -1061,8 +953,9 @@ mod test {
             "* * * * */10 *",
             "1,2,3/5 * * * * *",
             "0 0 0 1 1 ? 2020-2040/10",
+            "0 0 0 1 1 ? 2020-2040/2200",
         ] {
-            assert!(schedule.parse(valid_expression).is_ok());
+            assert!(parse_schedule(valid_expression).is_ok());
         }
     }
 }

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -436,6 +436,31 @@ fn zero_indexed_day_of_week_internal_ordinals_from_root_specifier(
                     let start = zero_indexed_day_of_week_from_numeric(*start)?;
                     (start..=6).collect()
                 }
+                Specifier::Range(start, end) => {
+                    let start_ordinal = zero_indexed_day_of_week_from_endpoint(start)?;
+                    let end_ordinal = zero_indexed_day_of_week_from_endpoint(end)?;
+                    return ordinal_range_values_with_step(
+                        start_ordinal,
+                        end_ordinal,
+                        0,
+                        6,
+                        wraparound_ranges,
+                        *step,
+                    )
+                    .map(|ordinals| {
+                        ordinals
+                            .into_iter()
+                            .map(zero_indexed_day_of_week_to_internal_ordinal)
+                            .collect()
+                    })
+                    .ok_or_else(|| {
+                        ErrorKind::Expression(format!(
+                            "Invalid range for Days of Week: {}-{}",
+                            start, end
+                        ))
+                        .into()
+                    });
+                }
                 specifier => {
                     zero_indexed_day_of_week_values_from_specifier(specifier, wraparound_ranges)?
                 }

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -494,9 +494,9 @@ where
 }
 
 fn is_leap_year(year: Ordinal) -> bool {
-    let by_four = year % 4 == 0;
-    let by_hundred = year % 100 == 0;
-    let by_four_hundred = year % 400 == 0;
+    let by_four = year.is_multiple_of(4);
+    let by_hundred = year.is_multiple_of(100);
+    let by_four_hundred = year.is_multiple_of(400);
     by_four && ((!by_hundred) || by_four_hundred)
 }
 

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -1,15 +1,236 @@
 use chrono::offset::TimeZone;
-use chrono::{DateTime, Datelike, Duration, Timelike};
+use chrono::{DateTime, Datelike, Duration, NaiveDate, Timelike};
+use std::ops::Bound;
+use std::ops::Bound::{Included, Unbounded};
 
 use crate::ordinal::Ordinal;
+use crate::schedule::ScheduleFields;
 use crate::time_unit::{DaysOfMonth, Hours, Minutes, Months, Seconds, TimeUnitField};
 
-// TODO: Possibility of one query struct?
+pub(crate) trait Cursor<Z>
+where
+    Z: TimeZone,
+{
+    fn initial_datetime(&self) -> &DateTime<Z>;
+    fn first_month(&mut self) -> &mut bool;
+    fn first_day_of_month(&mut self) -> &mut bool;
+    fn first_hour(&mut self) -> &mut bool;
+    fn first_minute(&mut self) -> &mut bool;
+    fn first_second(&mut self) -> &mut bool;
+
+    fn cursor_month_bound(&mut self, year: Ordinal, default: Ordinal) -> Ordinal {
+        if *self.first_month() {
+            *self.first_month() = false;
+            if year == self.initial_datetime().year() as u32 {
+                return self.initial_datetime().month();
+            }
+        }
+        default
+    }
+
+    fn cursor_day_of_month_bound(&mut self, default: Ordinal) -> Ordinal {
+        if *self.first_day_of_month() {
+            *self.first_day_of_month() = false;
+            return self.initial_datetime().day();
+        }
+        default
+    }
+
+    fn cursor_hour_bound(&mut self, default: Ordinal) -> Ordinal {
+        if *self.first_hour() {
+            *self.first_hour() = false;
+            return self.initial_datetime().hour();
+        }
+        default
+    }
+
+    fn cursor_minute_bound(&mut self, default: Ordinal) -> Ordinal {
+        if *self.first_minute() {
+            *self.first_minute() = false;
+            return self.initial_datetime().minute();
+        }
+        default
+    }
+
+    fn cursor_second_bound(&mut self, default: Ordinal) -> Ordinal {
+        if *self.first_second() {
+            *self.first_second() = false;
+            return self.initial_datetime().second();
+        }
+        default
+    }
+
+    fn reset_month(&mut self) {
+        *self.first_month() = false;
+        self.reset_day_of_month();
+    }
+
+    fn reset_day_of_month(&mut self) {
+        *self.first_day_of_month() = false;
+        self.reset_hour();
+    }
+
+    fn reset_hour(&mut self) {
+        *self.first_hour() = false;
+        self.reset_minute();
+    }
+
+    fn reset_minute(&mut self) {
+        *self.first_minute() = false;
+        self.reset_second();
+    }
+
+    fn reset_second(&mut self) {
+        *self.first_second() = false;
+    }
+}
+
+pub(crate) trait Query<Z>: Cursor<Z>
+where
+    Z: TimeZone,
+{
+    fn year_range(&self) -> (Bound<Ordinal>, Bound<Ordinal>);
+    fn month_default_bound(&self) -> Ordinal;
+    fn month_range(&self, bound: Ordinal) -> (Bound<Ordinal>, Bound<Ordinal>);
+    fn day_of_month_default_bound(&self) -> Ordinal;
+    fn day_of_month_range(
+        &self,
+        bound: Ordinal,
+        day_of_month_end: Ordinal,
+    ) -> (Bound<Ordinal>, Bound<Ordinal>);
+    fn hour_default_bound(&self) -> Ordinal;
+    fn hour_range(&self, bound: Ordinal) -> (Bound<Ordinal>, Bound<Ordinal>);
+    fn minute_default_bound(&self) -> Ordinal;
+    fn minute_range(&self, bound: Ordinal) -> (Bound<Ordinal>, Bound<Ordinal>);
+    fn second_default_bound(&self) -> Ordinal;
+    fn second_range(&self, bound: Ordinal) -> (Bound<Ordinal>, Bound<Ordinal>);
+    fn is_reversed(&self) -> bool;
+    fn preceeds_reference_datetime(&self, candidate: &DateTime<Z>) -> bool;
+    fn preferred_candidate(&self, lhs: DateTime<Z>, rhs: DateTime<Z>) -> DateTime<Z>;
+
+    fn years<'a>(&self, fields: &'a ScheduleFields) -> Box<dyn Iterator<Item = &'a Ordinal> + 'a> {
+        order_iter(
+            self.is_reversed(),
+            fields.years_ordinals().range(self.year_range()),
+        )
+    }
+
+    fn months<'a>(
+        &mut self,
+        fields: &'a ScheduleFields,
+        year: Ordinal,
+    ) -> Box<dyn Iterator<Item = &'a Ordinal> + 'a> {
+        let bound = self.cursor_month_bound(year, self.month_default_bound());
+        if !fields.months_ordinals().contains(&bound) {
+            self.reset_month();
+        }
+        order_iter(
+            self.is_reversed(),
+            fields.months_ordinals().range(self.month_range(bound)),
+        )
+    }
+
+    fn days_of_month<'a>(
+        &mut self,
+        fields: &'a ScheduleFields,
+        year: Ordinal,
+        month: Ordinal,
+    ) -> Box<dyn Iterator<Item = &'a Ordinal> + 'a> {
+        let day_of_month_end = days_in_month(month, year);
+        let bound = self.cursor_day_of_month_bound(self.day_of_month_default_bound());
+
+        let range = self.day_of_month_range(bound, day_of_month_end);
+        let iter = fields
+            .days_of_month_ordinals()
+            .range(range)
+            .filter(move |day| {
+                let day = **day;
+                fields.days_of_week_is_all()
+                    || NaiveDate::from_ymd_opt(year as i32, month, day)
+                        .map(|d| fields.includes_day_of_week(d.weekday().number_from_sunday()))
+                        .unwrap_or(false)
+            });
+
+        let mut ordered = order_iter(self.is_reversed(), iter).peekable();
+        let expected_start = bound.min(day_of_month_end);
+        if ordered.peek().map(|day| **day) != Some(expected_start) {
+            self.reset_day_of_month();
+        }
+        Box::new(ordered)
+    }
+
+    fn hours<'a>(
+        &mut self,
+        fields: &'a ScheduleFields,
+    ) -> Box<dyn Iterator<Item = &'a Ordinal> + 'a> {
+        let bound = self.cursor_hour_bound(self.hour_default_bound());
+        if !fields.hours_ordinals().contains(&bound) {
+            self.reset_hour();
+        }
+        order_iter(
+            self.is_reversed(),
+            fields.hours_ordinals().range(self.hour_range(bound)),
+        )
+    }
+
+    fn minutes<'a>(
+        &mut self,
+        fields: &'a ScheduleFields,
+        fold_hour_scan: bool,
+    ) -> Box<dyn Iterator<Item = &'a Ordinal> + 'a> {
+        let query_bound = self.cursor_minute_bound(self.minute_default_bound());
+        let bound = if fold_hour_scan {
+            self.minute_default_bound()
+        } else {
+            query_bound
+        };
+        if !fields.minutes_ordinals().contains(&bound) {
+            self.reset_minute();
+        }
+        order_iter(
+            self.is_reversed(),
+            fields.minutes_ordinals().range(self.minute_range(bound)),
+        )
+    }
+
+    fn seconds<'a>(
+        &mut self,
+        fields: &'a ScheduleFields,
+        fold_hour_scan: bool,
+    ) -> Box<dyn Iterator<Item = &'a Ordinal> + 'a> {
+        let query_bound = self.cursor_second_bound(self.second_default_bound());
+        let bound = if fold_hour_scan {
+            self.second_default_bound()
+        } else {
+            query_bound
+        };
+        if !fields.seconds_ordinals().contains(&bound) {
+            self.reset_second();
+        }
+        order_iter(
+            self.is_reversed(),
+            fields.seconds_ordinals().range(self.second_range(bound)),
+        )
+    }
+}
+
+fn order_iter<'a, I, T>(reverse: bool, iter: I) -> Box<dyn Iterator<Item = T> + 'a>
+where
+    I: DoubleEndedIterator<Item = T> + 'a,
+    T: 'a,
+{
+    if reverse {
+        Box::new(iter.rev())
+    } else {
+        Box::new(iter)
+    }
+}
 
 pub struct NextAfterQuery<Z>
 where
     Z: TimeZone,
 {
+    reference_datetime: DateTime<Z>,
     initial_datetime: DateTime<Z>,
     first_month: bool,
     first_day_of_month: bool,
@@ -24,6 +245,7 @@ where
 {
     pub fn from(after: &DateTime<Z>) -> NextAfterQuery<Z> {
         NextAfterQuery {
+            reference_datetime: after.clone(),
             initial_datetime: after.clone(),
             first_month: true,
             first_day_of_month: true,
@@ -32,81 +254,114 @@ where
             first_second: true,
         }
     }
+}
 
-    pub fn year_lower_bound(&self) -> Ordinal {
-        // Unlike the other units, years will never wrap around.
-        self.initial_datetime.year() as u32
+impl<Z> Cursor<Z> for NextAfterQuery<Z>
+where
+    Z: TimeZone,
+{
+    fn initial_datetime(&self) -> &DateTime<Z> {
+        &self.initial_datetime
     }
 
-    pub fn month_lower_bound(&mut self) -> Ordinal {
-        if self.first_month {
-            self.first_month = false;
-            return self.initial_datetime.month();
-        }
+    fn first_month(&mut self) -> &mut bool {
+        &mut self.first_month
+    }
+
+    fn first_day_of_month(&mut self) -> &mut bool {
+        &mut self.first_day_of_month
+    }
+
+    fn first_hour(&mut self) -> &mut bool {
+        &mut self.first_hour
+    }
+
+    fn first_minute(&mut self) -> &mut bool {
+        &mut self.first_minute
+    }
+
+    fn first_second(&mut self) -> &mut bool {
+        &mut self.first_second
+    }
+}
+
+impl<Z> Query<Z> for NextAfterQuery<Z>
+where
+    Z: TimeZone,
+{
+    fn year_range(&self) -> (Bound<Ordinal>, Bound<Ordinal>) {
+        (Included(self.initial_datetime.year() as u32), Unbounded)
+    }
+
+    fn month_default_bound(&self) -> Ordinal {
         Months::inclusive_min()
     }
 
-    pub fn reset_month(&mut self) {
-        self.first_month = false;
-        self.reset_day_of_month();
+    fn month_range(&self, bound: Ordinal) -> (Bound<Ordinal>, Bound<Ordinal>) {
+        (Included(bound), Included(Months::inclusive_max()))
     }
 
-    pub fn day_of_month_lower_bound(&mut self) -> Ordinal {
-        if self.first_day_of_month {
-            self.first_day_of_month = false;
-            return self.initial_datetime.day();
-        }
+    fn day_of_month_default_bound(&self) -> Ordinal {
         DaysOfMonth::inclusive_min()
     }
 
-    pub fn reset_day_of_month(&mut self) {
-        self.first_day_of_month = false;
-        self.reset_hour();
+    fn day_of_month_range(
+        &self,
+        bound: Ordinal,
+        day_of_month_end: Ordinal,
+    ) -> (Bound<Ordinal>, Bound<Ordinal>) {
+        (
+            Included(bound.min(day_of_month_end)),
+            Included(day_of_month_end),
+        )
     }
 
-    pub fn hour_lower_bound(&mut self) -> Ordinal {
-        if self.first_hour {
-            self.first_hour = false;
-            return self.initial_datetime.hour();
-        }
+    fn hour_default_bound(&self) -> Ordinal {
         Hours::inclusive_min()
     }
 
-    pub fn reset_hour(&mut self) {
-        self.first_hour = false;
-        self.reset_minute();
+    fn hour_range(&self, bound: Ordinal) -> (Bound<Ordinal>, Bound<Ordinal>) {
+        (Included(bound), Included(Hours::inclusive_max()))
     }
 
-    pub fn minute_lower_bound(&mut self) -> Ordinal {
-        if self.first_minute {
-            self.first_minute = false;
-            return self.initial_datetime.minute();
-        }
+    fn minute_default_bound(&self) -> Ordinal {
         Minutes::inclusive_min()
     }
 
-    pub fn reset_minute(&mut self) {
-        self.first_minute = false;
-        self.reset_second();
+    fn minute_range(&self, bound: Ordinal) -> (Bound<Ordinal>, Bound<Ordinal>) {
+        (Included(bound), Included(Minutes::inclusive_max()))
     }
 
-    pub fn second_lower_bound(&mut self) -> Ordinal {
-        if self.first_second {
-            self.first_second = false;
-            return self.initial_datetime.second();
-        }
+    fn second_default_bound(&self) -> Ordinal {
         Seconds::inclusive_min()
     }
 
-    pub fn reset_second(&mut self) {
-        self.first_second = false;
+    fn second_range(&self, bound: Ordinal) -> (Bound<Ordinal>, Bound<Ordinal>) {
+        (Included(bound), Included(Seconds::inclusive_max()))
     }
-} // End of impl
+
+    fn is_reversed(&self) -> bool {
+        false
+    }
+
+    fn preceeds_reference_datetime(&self, candidate: &DateTime<Z>) -> bool {
+        *candidate > self.reference_datetime
+    }
+
+    fn preferred_candidate(&self, lhs: DateTime<Z>, rhs: DateTime<Z>) -> DateTime<Z> {
+        if lhs < rhs {
+            lhs
+        } else {
+            rhs
+        }
+    }
+}
 
 pub struct PrevFromQuery<Z>
 where
     Z: TimeZone,
 {
+    reference_datetime: DateTime<Z>,
     initial_datetime: DateTime<Z>,
     first_month: bool,
     first_day_of_month: bool,
@@ -126,6 +381,7 @@ where
             before.clone() - Duration::seconds(1)
         };
         PrevFromQuery {
+            reference_datetime: before.clone(),
             initial_datetime,
             first_month: true,
             first_day_of_month: true,
@@ -134,73 +390,122 @@ where
             first_second: true,
         }
     }
+}
 
-    pub fn year_upper_bound(&self) -> Ordinal {
-        // Unlike the other units, years will never wrap around.
-        self.initial_datetime.year() as u32
+impl<Z> Cursor<Z> for PrevFromQuery<Z>
+where
+    Z: TimeZone,
+{
+    fn initial_datetime(&self) -> &DateTime<Z> {
+        &self.initial_datetime
     }
 
-    pub fn month_upper_bound(&mut self) -> Ordinal {
-        if self.first_month {
-            self.first_month = false;
-            return self.initial_datetime.month();
-        }
+    fn first_month(&mut self) -> &mut bool {
+        &mut self.first_month
+    }
+
+    fn first_day_of_month(&mut self) -> &mut bool {
+        &mut self.first_day_of_month
+    }
+
+    fn first_hour(&mut self) -> &mut bool {
+        &mut self.first_hour
+    }
+
+    fn first_minute(&mut self) -> &mut bool {
+        &mut self.first_minute
+    }
+
+    fn first_second(&mut self) -> &mut bool {
+        &mut self.first_second
+    }
+}
+
+impl<Z> Query<Z> for PrevFromQuery<Z>
+where
+    Z: TimeZone,
+{
+    fn year_range(&self) -> (Bound<Ordinal>, Bound<Ordinal>) {
+        (Unbounded, Included(self.initial_datetime.year() as u32))
+    }
+
+    fn month_default_bound(&self) -> Ordinal {
         Months::inclusive_max()
     }
 
-    pub fn reset_month(&mut self) {
-        self.first_month = false;
-        self.reset_day_of_month();
+    fn month_range(&self, bound: Ordinal) -> (Bound<Ordinal>, Bound<Ordinal>) {
+        (Included(Months::inclusive_min()), Included(bound))
     }
 
-    pub fn day_of_month_upper_bound(&mut self) -> Ordinal {
-        if self.first_day_of_month {
-            self.first_day_of_month = false;
-            return self.initial_datetime.day();
-        }
+    fn day_of_month_default_bound(&self) -> Ordinal {
         DaysOfMonth::inclusive_max()
     }
 
-    pub fn reset_day_of_month(&mut self) {
-        self.first_day_of_month = false;
-        self.reset_hour();
+    fn day_of_month_range(
+        &self,
+        bound: Ordinal,
+        day_of_month_end: Ordinal,
+    ) -> (Bound<Ordinal>, Bound<Ordinal>) {
+        (
+            Included(DaysOfMonth::inclusive_min()),
+            Included(bound.min(day_of_month_end)),
+        )
     }
 
-    pub fn hour_upper_bound(&mut self) -> Ordinal {
-        if self.first_hour {
-            self.first_hour = false;
-            return self.initial_datetime.hour();
-        }
+    fn hour_default_bound(&self) -> Ordinal {
         Hours::inclusive_max()
     }
 
-    pub fn reset_hour(&mut self) {
-        self.first_hour = false;
-        self.reset_minute();
+    fn hour_range(&self, bound: Ordinal) -> (Bound<Ordinal>, Bound<Ordinal>) {
+        (Included(Hours::inclusive_min()), Included(bound))
     }
 
-    pub fn minute_upper_bound(&mut self) -> Ordinal {
-        if self.first_minute {
-            self.first_minute = false;
-            return self.initial_datetime.minute();
-        }
+    fn minute_default_bound(&self) -> Ordinal {
         Minutes::inclusive_max()
     }
 
-    pub fn reset_minute(&mut self) {
-        self.first_minute = false;
-        self.reset_second();
+    fn minute_range(&self, bound: Ordinal) -> (Bound<Ordinal>, Bound<Ordinal>) {
+        (Included(Minutes::inclusive_min()), Included(bound))
     }
 
-    pub fn second_upper_bound(&mut self) -> Ordinal {
-        if self.first_second {
-            self.first_second = false;
-            return self.initial_datetime.second();
-        }
+    fn second_default_bound(&self) -> Ordinal {
         Seconds::inclusive_max()
     }
 
-    pub fn reset_second(&mut self) {
-        self.first_second = false;
+    fn second_range(&self, bound: Ordinal) -> (Bound<Ordinal>, Bound<Ordinal>) {
+        (Included(Seconds::inclusive_min()), Included(bound))
+    }
+
+    fn is_reversed(&self) -> bool {
+        true
+    }
+
+    fn preceeds_reference_datetime(&self, candidate: &DateTime<Z>) -> bool {
+        *candidate < self.reference_datetime
+    }
+
+    fn preferred_candidate(&self, lhs: DateTime<Z>, rhs: DateTime<Z>) -> DateTime<Z> {
+        if lhs > rhs {
+            lhs
+        } else {
+            rhs
+        }
+    }
+}
+
+fn is_leap_year(year: Ordinal) -> bool {
+    let by_four = year % 4 == 0;
+    let by_hundred = year % 100 == 0;
+    let by_four_hundred = year % 400 == 0;
+    by_four && ((!by_hundred) || by_four_hundred)
+}
+
+fn days_in_month(month: Ordinal, year: Ordinal) -> u32 {
+    let is_leap_year = is_leap_year(year);
+    match month {
+        9 | 4 | 6 | 11 => 30,
+        2 if is_leap_year => 29,
+        2 => 28,
+        _ => 31,
     }
 }

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -6,6 +6,7 @@ use std::ops::Bound::{Included, Unbounded};
 use crate::ordinal::Ordinal;
 use crate::schedule::ScheduleFields;
 use crate::time_unit::{DaysOfMonth, Hours, Minutes, Months, Seconds, TimeUnitField};
+use crate::DowDomOperand;
 
 pub(crate) trait Cursor<Z>
 where
@@ -135,25 +136,42 @@ where
         fields: &'a ScheduleFields,
         year: Ordinal,
         month: Ordinal,
-    ) -> Box<dyn Iterator<Item = &'a Ordinal> + 'a> {
+        operand: DowDomOperand,
+    ) -> Box<dyn Iterator<Item = Ordinal> + 'a> {
         let day_of_month_end = days_in_month(month, year);
         let bound = self.cursor_day_of_month_bound(self.day_of_month_default_bound());
 
         let range = self.day_of_month_range(bound, day_of_month_end);
-        let iter = fields
-            .days_of_month_ordinals()
-            .range(range)
-            .filter(move |day| {
-                let day = **day;
-                fields.days_of_week_is_all()
-                    || NaiveDate::from_ymd_opt(year as i32, month, day)
-                        .map(|d| fields.includes_day_of_week(d.weekday().number_from_sunday()))
-                        .unwrap_or(false)
-            });
+        let both_restricted = !fields.days_of_month_is_all() && !fields.days_of_week_is_all();
+        let should_scan_all_days = operand == DowDomOperand::Or && both_restricted;
+
+        let base_iter: Box<dyn DoubleEndedIterator<Item = Ordinal> + 'a> = if should_scan_all_days {
+            // TODO: Simplify this bound-to-range conversion when
+            // https://github.com/rust-lang/rust/issues/136903 lands.
+            let start = match range.0 {
+                Included(value) => value,
+                Bound::Excluded(value) => value + 1,
+                Unbounded => DaysOfMonth::inclusive_min(),
+            };
+            let end = match range.1 {
+                Included(value) => value,
+                Bound::Excluded(value) => value.saturating_sub(1),
+                Unbounded => DaysOfMonth::inclusive_max(),
+            };
+            Box::new(start..=end)
+        } else {
+            Box::new(fields.days_of_month_ordinals().range(range).copied())
+        };
+
+        let iter = base_iter.filter(move |day| {
+            NaiveDate::from_ymd_opt(year as i32, month, *day)
+                .map(|d| fields.day_matches(*day, d.weekday().number_from_sunday(), operand))
+                .unwrap_or(false)
+        });
 
         let mut ordered = order_iter(self.is_reversed(), iter).peekable();
         let expected_start = bound.min(day_of_month_end);
-        if ordered.peek().map(|day| **day) != Some(expected_start) {
+        if ordered.peek().copied() != Some(expected_start) {
             self.reset_day_of_month();
         }
         Box::new(ordered)

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -25,6 +25,7 @@ where
             if year == self.initial_datetime().year() as u32 {
                 return self.initial_datetime().month();
             }
+            self.reset_day_of_month();
         }
         default
     }
@@ -90,7 +91,7 @@ pub(crate) trait Query<Z>: Cursor<Z>
 where
     Z: TimeZone,
 {
-    fn year_range(&self) -> (Bound<Ordinal>, Bound<Ordinal>);
+    fn year_range(&self, search_interval: Duration) -> (Bound<Ordinal>, Bound<Ordinal>);
     fn month_default_bound(&self) -> Ordinal;
     fn month_range(&self, bound: Ordinal) -> (Bound<Ordinal>, Bound<Ordinal>);
     fn day_of_month_default_bound(&self) -> Ordinal;
@@ -109,11 +110,24 @@ where
     fn preceeds_reference_datetime(&self, candidate: &DateTime<Z>) -> bool;
     fn preferred_candidate(&self, lhs: DateTime<Z>, rhs: DateTime<Z>) -> DateTime<Z>;
 
-    fn years<'a>(&self, fields: &'a ScheduleFields) -> Box<dyn Iterator<Item = &'a Ordinal> + 'a> {
-        order_iter(
-            self.is_reversed(),
-            fields.years_ordinals().range(self.year_range()),
-        )
+    fn years<'a>(
+        &self,
+        fields: &'a ScheduleFields,
+        search_interval: Duration,
+    ) -> Box<dyn Iterator<Item = Ordinal> + 'a> {
+        let Some((start, end)) = ordinal_bounds(self.year_range(search_interval)) else {
+            return Box::new(std::iter::empty());
+        };
+
+        if start > end {
+            return Box::new(std::iter::empty());
+        }
+
+        if fields.years_are_unrestricted() {
+            return order_iter(self.is_reversed(), start..=end);
+        }
+
+        order_iter(self.is_reversed(), fields.years_between(start, end))
     }
 
     fn months<'a>(
@@ -232,6 +246,26 @@ where
     }
 }
 
+fn ordinal_bounds(range: (Bound<Ordinal>, Bound<Ordinal>)) -> Option<(Ordinal, Ordinal)> {
+    Some((lower_ordinal_bound(range.0)?, upper_ordinal_bound(range.1)?))
+}
+
+fn lower_ordinal_bound(bound: Bound<Ordinal>) -> Option<Ordinal> {
+    match bound {
+        Included(ordinal) => Some(ordinal),
+        Bound::Excluded(ordinal) => ordinal.checked_add(1),
+        Unbounded => Some(0),
+    }
+}
+
+fn upper_ordinal_bound(bound: Bound<Ordinal>) -> Option<Ordinal> {
+    match bound {
+        Included(ordinal) => Some(ordinal),
+        Bound::Excluded(ordinal) => ordinal.checked_sub(1),
+        Unbounded => Some(i32::MAX as Ordinal),
+    }
+}
+
 pub struct NextAfterQuery<Z>
 where
     Z: TimeZone,
@@ -295,8 +329,15 @@ impl<Z> Query<Z> for NextAfterQuery<Z>
 where
     Z: TimeZone,
 {
-    fn year_range(&self) -> (Bound<Ordinal>, Bound<Ordinal>) {
-        (Included(self.initial_datetime.year() as u32), Unbounded)
+    fn year_range(&self, search_interval: Duration) -> (Bound<Ordinal>, Bound<Ordinal>) {
+        let upper = self
+            .initial_datetime
+            .clone()
+            .checked_add_signed(search_interval)
+            .map(|datetime| Included(datetime.year() as u32))
+            .unwrap_or(Unbounded);
+
+        (Included(self.initial_datetime.year() as u32), upper)
     }
 
     fn month_default_bound(&self) -> Ordinal {
@@ -428,8 +469,15 @@ impl<Z> Query<Z> for PrevFromQuery<Z>
 where
     Z: TimeZone,
 {
-    fn year_range(&self) -> (Bound<Ordinal>, Bound<Ordinal>) {
-        (Unbounded, Included(self.initial_datetime.year() as u32))
+    fn year_range(&self, search_interval: Duration) -> (Bound<Ordinal>, Bound<Ordinal>) {
+        let lower = self
+            .initial_datetime
+            .clone()
+            .checked_sub_signed(search_interval)
+            .map(|datetime| Included(datetime.year() as u32))
+            .unwrap_or(Unbounded);
+
+        (lower, Included(self.initial_datetime.year() as u32))
     }
 
     fn month_default_bound(&self) -> Ordinal {

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -1,7 +1,7 @@
 use chrono::offset::TimeZone;
 use chrono::{DateTime, Datelike, Duration, NaiveDate, Timelike};
-use std::ops::Bound;
 use std::ops::Bound::{Included, Unbounded};
+use std::ops::{Bound, RangeInclusive};
 
 use crate::ordinal::Ordinal;
 use crate::schedule::ScheduleFields;
@@ -98,7 +98,7 @@ where
         &self,
         bound: Ordinal,
         day_of_month_end: Ordinal,
-    ) -> (Bound<Ordinal>, Bound<Ordinal>);
+    ) -> RangeInclusive<Ordinal>;
     fn hour_default_bound(&self) -> Ordinal;
     fn hour_range(&self, bound: Ordinal) -> (Bound<Ordinal>, Bound<Ordinal>);
     fn minute_default_bound(&self) -> Ordinal;
@@ -146,19 +146,7 @@ where
         let should_scan_all_days = operand == DowDomOperand::Or && both_restricted;
 
         let base_iter: Box<dyn DoubleEndedIterator<Item = Ordinal> + 'a> = if should_scan_all_days {
-            // TODO: Simplify this bound-to-range conversion when
-            // https://github.com/rust-lang/rust/issues/136903 lands.
-            let start = match range.0 {
-                Included(value) => value,
-                Bound::Excluded(value) => value + 1,
-                Unbounded => DaysOfMonth::inclusive_min(),
-            };
-            let end = match range.1 {
-                Included(value) => value,
-                Bound::Excluded(value) => value.saturating_sub(1),
-                Unbounded => DaysOfMonth::inclusive_max(),
-            };
-            Box::new(start..=end)
+            Box::new(range)
         } else {
             Box::new(fields.days_of_month_ordinals().range(range).copied())
         };
@@ -327,11 +315,8 @@ where
         &self,
         bound: Ordinal,
         day_of_month_end: Ordinal,
-    ) -> (Bound<Ordinal>, Bound<Ordinal>) {
-        (
-            Included(bound.min(day_of_month_end)),
-            Included(day_of_month_end),
-        )
+    ) -> RangeInclusive<Ordinal> {
+        bound.min(day_of_month_end)..=day_of_month_end
     }
 
     fn hour_default_bound(&self) -> Ordinal {
@@ -463,11 +448,8 @@ where
         &self,
         bound: Ordinal,
         day_of_month_end: Ordinal,
-    ) -> (Bound<Ordinal>, Bound<Ordinal>) {
-        (
-            Included(DaysOfMonth::inclusive_min()),
-            Included(bound.min(day_of_month_end)),
-        )
+    ) -> RangeInclusive<Ordinal> {
+        DaysOfMonth::inclusive_min()..=bound.min(day_of_month_end)
     }
 
     fn hour_default_bound(&self) -> Ordinal {

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -1,5 +1,5 @@
 use chrono::offset::{LocalResult, TimeZone};
-use chrono::{DateTime, Datelike, Timelike, Utc};
+use chrono::{DateTime, Datelike, TimeDelta, Timelike, Utc};
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
 #[cfg(feature = "serde")]
@@ -10,9 +10,11 @@ use serde::{
     Deserialize, Serialize, Serializer,
 };
 
+use crate::error::Error;
 use crate::ordinal::*;
 use crate::queries::*;
 use crate::time_unit::*;
+use crate::{CronScheduleParts, DayOfWeekNumbering, DowDomOperand, ScheduleConfig};
 
 impl From<Schedule> for String {
     fn from(schedule: Schedule) -> String {
@@ -24,11 +26,34 @@ impl From<Schedule> for String {
 pub struct Schedule {
     source: String,
     fields: ScheduleFields,
+    config: ScheduleConfig,
 }
 
 impl Schedule {
-    pub(crate) fn new(source: String, fields: ScheduleFields) -> Schedule {
-        Schedule { source, fields }
+    /// Returns a builder configured with default parsing behavior.
+    pub fn builder() -> ScheduleConfigBuilder {
+        ScheduleConfigBuilder::default()
+    }
+
+    /// Returns a default parser builder.
+    #[allow(clippy::should_implement_trait)]
+    pub fn default() -> ScheduleConfigBuilder {
+        Schedule::builder()
+    }
+
+    /// Returns a parser builder configured for Vixie day-of-week numbering (0-6).
+    pub fn vixie() -> ScheduleConfigBuilder {
+        Schedule::builder()
+            .day_of_week_numbering(DayOfWeekNumbering::ZeroToSix)
+            .dow_dom_operand(DowDomOperand::Or)
+    }
+
+    pub(crate) fn new(source: String, fields: ScheduleFields, config: ScheduleConfig) -> Schedule {
+        Schedule {
+            source,
+            fields,
+            config,
+        }
     }
 
     fn next_after<Z>(&self, after: &DateTime<Z>) -> Option<DateTime<Z>>
@@ -60,19 +85,21 @@ impl Schedule {
         };
         for year in query.years(&self.fields) {
             for month in query.months(&self.fields, *year) {
-                for day_of_month in query.days_of_month(&self.fields, *year, *month) {
+                for day_of_month in
+                    query.days_of_month(&self.fields, *year, *month, self.config.dow_dom_operand)
+                {
                     for hour in query.hours(&self.fields) {
                         let fold_hour_scan = fold_scan_active
                             && *year as i32 == reference_naive.year()
                             && *month == reference_naive.month()
-                            && *day_of_month == reference_naive.day()
+                            && day_of_month == reference_naive.day()
                             && *hour == reference_naive.hour();
                         for minute in query.minutes(&self.fields, fold_hour_scan) {
                             for second in query.seconds(&self.fields, fold_hour_scan) {
                                 let local_result = datetime.timezone().with_ymd_and_hms(
                                     *year as i32,
                                     *month,
-                                    *day_of_month,
+                                    day_of_month,
                                     *hour,
                                     *minute,
                                     *second,
@@ -82,6 +109,13 @@ impl Schedule {
                                     LocalResult::Single(candidate) => {
                                         if !query.preceeds_reference_datetime(&candidate) {
                                             continue;
+                                        }
+                                        if !self.within_search_interval(
+                                            datetime,
+                                            &candidate,
+                                            query.is_reversed(),
+                                        ) {
+                                            return deferred_candidate;
                                         }
                                         if let Some(deferred) = deferred_candidate.take() {
                                             return Some(
@@ -93,7 +127,13 @@ impl Schedule {
                                     LocalResult::Ambiguous(earlier, later) => {
                                         let primary = query
                                             .preferred_candidate(earlier.clone(), later.clone());
-                                        if query.preceeds_reference_datetime(&primary) {
+                                        if query.preceeds_reference_datetime(&primary)
+                                            && self.within_search_interval(
+                                                datetime,
+                                                &primary,
+                                                query.is_reversed(),
+                                            )
+                                        {
                                             if let Some(deferred) = deferred_candidate.take() {
                                                 return Some(
                                                     query.preferred_candidate(deferred, primary),
@@ -104,7 +144,13 @@ impl Schedule {
 
                                         let secondary =
                                             if primary == earlier { later } else { earlier };
-                                        if query.preceeds_reference_datetime(&secondary) {
+                                        if query.preceeds_reference_datetime(&secondary)
+                                            && self.within_search_interval(
+                                                datetime,
+                                                &secondary,
+                                                query.is_reversed(),
+                                            )
+                                        {
                                             deferred_candidate =
                                                 Some(match deferred_candidate.take() {
                                                     Some(existing) => query
@@ -159,16 +205,13 @@ impl Schedule {
     where
         Z: TimeZone,
     {
+        let day_of_month = date_time.day() as Ordinal;
+        let day_of_week = date_time.weekday().number_from_sunday();
         self.fields.years.includes(date_time.year() as Ordinal)
             && self.fields.months.includes(date_time.month() as Ordinal)
             && self
                 .fields
-                .days_of_week
-                .includes(date_time.weekday().number_from_sunday())
-            && self
-                .fields
-                .days_of_month
-                .includes(date_time.day() as Ordinal)
+                .day_matches(day_of_month, day_of_week, self.config.dow_dom_operand)
             && self.fields.hours.includes(date_time.hour() as Ordinal)
             && self.fields.minutes.includes(date_time.minute() as Ordinal)
             && self.fields.seconds.includes(date_time.second() as Ordinal)
@@ -216,6 +259,71 @@ impl Schedule {
     /// Returns a reference to the source cron expression.
     pub fn source(&self) -> &str {
         &self.source
+    }
+
+    /// Returns the parsing configuration associated with this schedule.
+    pub fn config(&self) -> ScheduleConfig {
+        self.config
+    }
+
+    fn within_search_interval<Z>(
+        &self,
+        reference_datetime: &DateTime<Z>,
+        candidate: &DateTime<Z>,
+        reversed: bool,
+    ) -> bool
+    where
+        Z: TimeZone,
+    {
+        let elapsed = if reversed {
+            reference_datetime
+                .clone()
+                .signed_duration_since(candidate.clone())
+        } else {
+            candidate
+                .clone()
+                .signed_duration_since(reference_datetime.clone())
+        };
+        elapsed <= self.config.search_interval
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub struct ScheduleConfigBuilder {
+    config: ScheduleConfig,
+}
+
+impl ScheduleConfigBuilder {
+    pub fn allowed_cron_schedule_parts(mut self, parts: CronScheduleParts) -> Self {
+        self.config.cron_schedule_parts = parts;
+        self
+    }
+
+    pub fn day_of_week_numbering(mut self, numbering: DayOfWeekNumbering) -> Self {
+        self.config.day_of_week_numbering = numbering;
+        self
+    }
+
+    pub fn dow_dom_operand(mut self, operand: DowDomOperand) -> Self {
+        self.config.dow_dom_operand = operand;
+        self
+    }
+
+    pub fn days_matching(self, operand: DowDomOperand) -> Self {
+        self.dow_dom_operand(operand)
+    }
+
+    pub fn search_interval(mut self, interval: TimeDelta) -> Self {
+        self.config.search_interval = interval;
+        self
+    }
+
+    pub fn parse(self, expression: &str) -> Result<Schedule, Error> {
+        Schedule::from_str_with_config(expression, self.config)
+    }
+
+    pub fn config(&self) -> ScheduleConfig {
+        self.config
     }
 }
 
@@ -291,8 +399,35 @@ impl ScheduleFields {
         self.days_of_week.is_all()
     }
 
+    pub(crate) fn days_of_month_is_all(&self) -> bool {
+        self.days_of_month.is_all()
+    }
+
+    pub(crate) fn includes_day_of_month(&self, day_of_month: Ordinal) -> bool {
+        self.days_of_month.ordinals().contains(&day_of_month)
+    }
+
     pub(crate) fn includes_day_of_week(&self, day_of_week: Ordinal) -> bool {
         self.days_of_week.ordinals().contains(&day_of_week)
+    }
+
+    pub(crate) fn day_matches(
+        &self,
+        day_of_month: Ordinal,
+        day_of_week: Ordinal,
+        operand: DowDomOperand,
+    ) -> bool {
+        let dom_matches = self.includes_day_of_month(day_of_month);
+        let dow_matches = self.includes_day_of_week(day_of_week);
+        let both_restricted = !self.days_of_month_is_all() && !self.days_of_week_is_all();
+        if both_restricted {
+            match operand {
+                DowDomOperand::And => dom_matches && dow_matches,
+                DowDomOperand::Or => dom_matches || dow_matches,
+            }
+        } else {
+            dom_matches && dow_matches
+        }
     }
 }
 

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -1,8 +1,6 @@
 use chrono::offset::{LocalResult, TimeZone};
-use chrono::{DateTime, Datelike, NaiveDate, Timelike, Utc};
-use std::cmp::{max, min};
+use chrono::{DateTime, Datelike, Timelike, Utc};
 use std::fmt::{Display, Formatter, Result as FmtResult};
-use std::ops::Bound::{Included, Unbounded};
 
 #[cfg(feature = "serde")]
 use core::fmt;
@@ -37,374 +35,97 @@ impl Schedule {
     where
         Z: TimeZone,
     {
-        let mut query = NextAfterQuery::from(after);
-        // Ambiguous naive datetimes translate to two local datetimes. This
-        // iteration uses naive datetimes and could skip the second local
-        // datetime, where the second may match the pattern. This deferred
-        // candidate retains that datetime for consideration on subsequent
-        // iterations. For example, during fall back, `0 0/30 * * * * *` must
-        // emit both 01:30 local datetimes.
-        let mut deferred_candidate: Option<DateTime<Z>> = None;
-        // Folded time happens during the fall back DST transition where an
-        // offset, typically one hour, is repeated in both timezones. This flag
-        // tells iteration it is starting in the first repeated offset so it
-        // does not get stuck repeating matches from the first fold or skip
-        // matches in the second fold.
-        let after_naive = after.naive_local();
-        let after_in_first_fold = match after.timezone().from_local_datetime(&after_naive) {
-            LocalResult::Ambiguous(first, second) => {
-                let earlier = min(first, second);
-                *after == earlier
-            }
-            _ => false,
-        };
-        for year in self
-            .fields
-            .years
-            .ordinals()
-            .range((Included(query.year_lower_bound()), Unbounded))
-            .cloned()
-        {
-            // It's a future year, the current year's range is irrelevant.
-            if year > after.year() as u32 {
-                query.reset_month();
-            }
-            let month_start = query.month_lower_bound();
-            if !self.fields.months.ordinals().contains(&month_start) {
-                query.reset_month();
-            }
-            let month_range = (Included(month_start), Included(Months::inclusive_max()));
-            for month in self.fields.months.ordinals().range(month_range).cloned() {
-                let day_of_month_start = query.day_of_month_lower_bound();
-                if !self
-                    .fields
-                    .days_of_month
-                    .ordinals()
-                    .contains(&day_of_month_start)
-                {
-                    query.reset_day_of_month();
-                }
-                let day_of_month_end = days_in_month(month, year);
-                let day_of_month_range = (
-                    Included(day_of_month_start.min(day_of_month_end)),
-                    Included(day_of_month_end),
-                );
-
-                let mut day_iter = self
-                    .fields
-                    .days_of_month
-                    .ordinals()
-                    .range(day_of_month_range)
-                    .cloned()
-                    .filter(|&day| {
-                        self.fields.days_of_week.is_all()
-                            || NaiveDate::from_ymd_opt(year as i32, month, day)
-                                .map(|d| {
-                                    self.fields
-                                        .days_of_week
-                                        .ordinals()
-                                        .contains(&d.weekday().number_from_sunday())
-                                })
-                                .unwrap_or(false)
-                    })
-                    .peekable();
-                if day_iter.peek() != Some(&day_of_month_start) {
-                    query.reset_day_of_month();
-                }
-                for day_of_month in day_iter {
-                    let hour_start = query.hour_lower_bound();
-                    if !self.fields.hours.ordinals().contains(&hour_start) {
-                        query.reset_hour();
-                    }
-                    let hour_range = (Included(hour_start), Included(Hours::inclusive_max()));
-
-                    for hour in self.fields.hours.ordinals().range(hour_range).cloned() {
-                        // The first fold is the first repeat of the DST offset,
-                        // typically one hour. Because this iteration is done in
-                        // naive time, it can skip matches after finding one in
-                        // the first fold. For example, `0 0/30 * * * * *` must
-                        // continue from 01:00 to 01:30 in both folds.
-                        let fold_hour_scan = after_in_first_fold
-                            && year as i32 == after_naive.year()
-                            && month == after_naive.month()
-                            && day_of_month == after_naive.day()
-                            && hour == after_naive.hour();
-                        let query_minute_start = query.minute_lower_bound();
-                        let minute_start = if fold_hour_scan {
-                            Minutes::inclusive_min()
-                        } else {
-                            query_minute_start
-                        };
-                        if !self.fields.minutes.ordinals().contains(&minute_start) {
-                            query.reset_minute();
-                        }
-                        let minute_range =
-                            (Included(minute_start), Included(Minutes::inclusive_max()));
-
-                        for minute in self.fields.minutes.ordinals().range(minute_range).cloned() {
-                            let query_second_start = query.second_lower_bound();
-                            let second_start = if fold_hour_scan {
-                                Seconds::inclusive_min()
-                            } else {
-                                query_second_start
-                            };
-                            if !self.fields.seconds.ordinals().contains(&second_start) {
-                                query.reset_second();
-                            }
-                            let second_range =
-                                (Included(second_start), Included(Seconds::inclusive_max()));
-
-                            for second in
-                                self.fields.seconds.ordinals().range(second_range).cloned()
-                            {
-                                let timezone = after.timezone();
-                                let local_result = timezone.with_ymd_and_hms(
-                                    year as i32,
-                                    month,
-                                    day_of_month,
-                                    hour,
-                                    minute,
-                                    second,
-                                );
-                                match local_result {
-                                    LocalResult::None => continue,
-                                    LocalResult::Single(candidate) => {
-                                        if candidate <= *after {
-                                            continue;
-                                        }
-                                        if let Some(deferred) = deferred_candidate.take() {
-                                            return Some(min(deferred, candidate));
-                                        }
-                                        return Some(candidate);
-                                    }
-                                    LocalResult::Ambiguous(earlier, later) => {
-                                        if earlier > *after {
-                                            if let Some(deferred) = deferred_candidate.take() {
-                                                return Some(min(deferred, earlier));
-                                            }
-                                            return Some(earlier);
-                                        }
-                                        if later > *after {
-                                            deferred_candidate = Some(match deferred_candidate {
-                                                Some(existing) => min(existing, later),
-                                                _ => later,
-                                            });
-                                        }
-                                    }
-                                }
-                            }
-                            query.reset_minute();
-                        } // End of minutes range
-                        query.reset_hour();
-                    } // End of hours range
-                    query.reset_day_of_month();
-                } // End of Day of Month range
-                query.reset_month();
-            } // End of Month range
-        }
-
-        if let Some(candidate) = deferred_candidate {
-            return Some(candidate);
-        }
-        // We ran out of dates to try.
-        None
+        self.find_with_query(NextAfterQuery::from(after), after)
     }
 
     fn prev_from<Z>(&self, before: &DateTime<Z>) -> Option<DateTime<Z>>
     where
         Z: TimeZone,
     {
-        let mut query = PrevFromQuery::from(before);
-        // See `next_after` for folded-time details. This is the reverse scan's
-        // deferred candidate for an earlier local datetime that may still be
-        // the previous chronological match.
+        self.find_with_query(PrevFromQuery::from(before), before)
+    }
+
+    fn find_with_query<Z, Q>(&self, mut query: Q, datetime: &DateTime<Z>) -> Option<DateTime<Z>>
+    where
+        Z: TimeZone,
+        Q: Query<Z>,
+    {
         let mut deferred_candidate: Option<DateTime<Z>> = None;
-        // See `next_after` for folded-time details. This flag handles starting
-        // from the second fold while scanning backward.
-        let before_naive = before.naive_local();
-        let before_in_second_fold = match before.timezone().from_local_datetime(&before_naive) {
+        let reference_naive = datetime.naive_local();
+        let fold_scan_active = match datetime.timezone().from_local_datetime(&reference_naive) {
             LocalResult::Ambiguous(first, second) => {
-                let later = max(first, second);
-                *before == later
+                *datetime == query.preferred_candidate(first, second)
             }
             _ => false,
         };
-        for year in self
-            .fields
-            .years
-            .ordinals()
-            .range((Unbounded, Included(query.year_upper_bound())))
-            .rev()
-            .cloned()
-        {
-            let month_start = query.month_upper_bound();
-
-            if !self.fields.months.ordinals().contains(&month_start) {
-                query.reset_month();
-            }
-            let month_range = (Included(Months::inclusive_min()), Included(month_start));
-
-            for month in self
-                .fields
-                .months
-                .ordinals()
-                .range(month_range)
-                .rev()
-                .cloned()
-            {
-                let day_of_month_end = query.day_of_month_upper_bound();
-                if !self
-                    .fields
-                    .days_of_month
-                    .ordinals()
-                    .contains(&day_of_month_end)
-                {
-                    query.reset_day_of_month();
-                }
-
-                let day_of_month_end = days_in_month(month, year).min(day_of_month_end);
-
-                let day_of_month_range = (
-                    Included(DaysOfMonth::inclusive_min()),
-                    Included(day_of_month_end),
-                );
-
-                let mut day_iter = self
-                    .fields
-                    .days_of_month
-                    .ordinals()
-                    .range(day_of_month_range)
-                    .rev()
-                    .cloned()
-                    .filter(|&day| {
-                        self.fields.days_of_week.is_all()
-                            || NaiveDate::from_ymd_opt(year as i32, month, day)
-                                .map(|d| {
-                                    self.fields
-                                        .days_of_week
-                                        .ordinals()
-                                        .contains(&d.weekday().number_from_sunday())
-                                })
-                                .unwrap_or(false)
-                    })
-                    .peekable();
-                if day_iter.peek() != Some(&day_of_month_end) {
-                    query.reset_day_of_month();
-                }
-                for day_of_month in day_iter {
-                    let hour_start = query.hour_upper_bound();
-                    if !self.fields.hours.ordinals().contains(&hour_start) {
-                        query.reset_hour();
-                    }
-                    let hour_range = (Included(Hours::inclusive_min()), Included(hour_start));
-
-                    for hour in self
-                        .fields
-                        .hours
-                        .ordinals()
-                        .range(hour_range)
-                        .rev()
-                        .cloned()
-                    {
-                        // See the forward `fold_hour_scan` for folded-time
-                        // details. This is the reverse scan of the repeated
-                        // hour from the second fold into the first.
-                        let fold_hour_scan = before_in_second_fold
-                            && year as i32 == before_naive.year()
-                            && month == before_naive.month()
-                            && day_of_month == before_naive.day()
-                            && hour == before_naive.hour();
-                        let query_minute_start = query.minute_upper_bound();
-                        let minute_start = if fold_hour_scan {
-                            Minutes::inclusive_max()
-                        } else {
-                            query_minute_start
-                        };
-                        if !self.fields.minutes.ordinals().contains(&minute_start) {
-                            query.reset_minute();
-                        }
-                        let minute_range =
-                            (Included(Minutes::inclusive_min()), Included(minute_start));
-
-                        for minute in self
-                            .fields
-                            .minutes
-                            .ordinals()
-                            .range(minute_range)
-                            .rev()
-                            .cloned()
-                        {
-                            let query_second_start = query.second_upper_bound();
-                            let second_start = if fold_hour_scan {
-                                Seconds::inclusive_max()
-                            } else {
-                                query_second_start
-                            };
-                            if !self.fields.seconds.ordinals().contains(&second_start) {
-                                query.reset_second();
-                            }
-                            let second_range =
-                                (Included(Seconds::inclusive_min()), Included(second_start));
-
-                            for second in self
-                                .fields
-                                .seconds
-                                .ordinals()
-                                .range(second_range)
-                                .rev()
-                                .cloned()
-                            {
-                                let timezone = before.timezone();
-                                let local_result = timezone.with_ymd_and_hms(
-                                    year as i32,
-                                    month,
-                                    day_of_month,
-                                    hour,
-                                    minute,
-                                    second,
+        for year in query.years(&self.fields) {
+            for month in query.months(&self.fields, *year) {
+                for day_of_month in query.days_of_month(&self.fields, *year, *month) {
+                    for hour in query.hours(&self.fields) {
+                        let fold_hour_scan = fold_scan_active
+                            && *year as i32 == reference_naive.year()
+                            && *month == reference_naive.month()
+                            && *day_of_month == reference_naive.day()
+                            && *hour == reference_naive.hour();
+                        for minute in query.minutes(&self.fields, fold_hour_scan) {
+                            for second in query.seconds(&self.fields, fold_hour_scan) {
+                                let local_result = datetime.timezone().with_ymd_and_hms(
+                                    *year as i32,
+                                    *month,
+                                    *day_of_month,
+                                    *hour,
+                                    *minute,
+                                    *second,
                                 );
                                 match local_result {
                                     LocalResult::None => continue,
                                     LocalResult::Single(candidate) => {
-                                        if candidate >= *before {
+                                        if !query.preceeds_reference_datetime(&candidate) {
                                             continue;
                                         }
                                         if let Some(deferred) = deferred_candidate.take() {
-                                            return Some(max(deferred, candidate));
+                                            return Some(
+                                                query.preferred_candidate(deferred, candidate),
+                                            );
                                         }
                                         return Some(candidate);
                                     }
                                     LocalResult::Ambiguous(earlier, later) => {
-                                        if later < *before {
+                                        let primary = query
+                                            .preferred_candidate(earlier.clone(), later.clone());
+                                        if query.preceeds_reference_datetime(&primary) {
                                             if let Some(deferred) = deferred_candidate.take() {
-                                                return Some(max(deferred, later));
+                                                return Some(
+                                                    query.preferred_candidate(deferred, primary),
+                                                );
                                             }
-                                            return Some(later);
+                                            return Some(primary);
                                         }
-                                        if earlier < *before {
-                                            deferred_candidate = Some(match deferred_candidate {
-                                                Some(existing) => max(existing, earlier),
-                                                _ => earlier,
-                                            });
+
+                                        let secondary =
+                                            if primary == earlier { later } else { earlier };
+                                        if query.preceeds_reference_datetime(&secondary) {
+                                            deferred_candidate =
+                                                Some(match deferred_candidate.take() {
+                                                    Some(existing) => query
+                                                        .preferred_candidate(existing, secondary),
+                                                    None => secondary,
+                                                });
                                         }
                                     }
                                 }
                             }
                             query.reset_minute();
-                        } // End of minutes range
+                        }
                         query.reset_hour();
-                    } // End of hours range
+                    }
                     query.reset_day_of_month();
-                } // End of Day of Month range
+                }
                 query.reset_month();
-            } // End of Month range
+            }
         }
 
-        if let Some(candidate) = deferred_candidate {
-            return Some(candidate);
-        }
-        // We ran out of dates to try.
-        None
+        deferred_candidate
     }
 
     /// Provides an iterator which will return each DateTime that matches the schedule starting with
@@ -541,6 +262,38 @@ impl ScheduleFields {
             seconds,
         }
     }
+
+    pub(crate) fn years_ordinals(&self) -> &OrdinalSet {
+        self.years.ordinals()
+    }
+
+    pub(crate) fn months_ordinals(&self) -> &OrdinalSet {
+        self.months.ordinals()
+    }
+
+    pub(crate) fn days_of_month_ordinals(&self) -> &OrdinalSet {
+        self.days_of_month.ordinals()
+    }
+
+    pub(crate) fn hours_ordinals(&self) -> &OrdinalSet {
+        self.hours.ordinals()
+    }
+
+    pub(crate) fn minutes_ordinals(&self) -> &OrdinalSet {
+        self.minutes.ordinals()
+    }
+
+    pub(crate) fn seconds_ordinals(&self) -> &OrdinalSet {
+        self.seconds.ordinals()
+    }
+
+    pub(crate) fn days_of_week_is_all(&self) -> bool {
+        self.days_of_week.is_all()
+    }
+
+    pub(crate) fn includes_day_of_week(&self, day_of_week: Ordinal) -> bool {
+        self.days_of_week.ordinals().contains(&day_of_week)
+    }
 }
 
 pub struct ScheduleIterator<'a, Z>
@@ -635,23 +388,6 @@ impl<Z: TimeZone> DoubleEndedIterator for OwnedScheduleIterator<Z> {
         let prev = self.schedule.prev_from(&previous)?;
         self.previous_datetime = Some(prev.clone());
         Some(prev)
-    }
-}
-
-fn is_leap_year(year: Ordinal) -> bool {
-    let by_four = year.is_multiple_of(4);
-    let by_hundred = year.is_multiple_of(100);
-    let by_four_hundred = year.is_multiple_of(400);
-    by_four && ((!by_hundred) || by_four_hundred)
-}
-
-fn days_in_month(month: Ordinal, year: Ordinal) -> u32 {
-    let is_leap_year = is_leap_year(year);
-    match month {
-        9 | 4 | 6 | 11 => 30,
-        2 if is_leap_year => 29,
-        2 => 28,
-        _ => 31,
     }
 }
 

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -117,6 +117,7 @@ impl Schedule {
                                     LocalResult::None => {
                                         if self.config.nonexistent_time_behavior
                                             == NonexistentTimeBehavior::Skip
+                                            || self.fields.is_hourly_or_more_frequent()
                                         {
                                             continue;
                                         }
@@ -568,6 +569,12 @@ impl ScheduleFields {
 
     pub(crate) fn seconds_ordinals(&self) -> &OrdinalSet {
         self.seconds.ordinals()
+    }
+
+    pub(crate) fn is_hourly_or_more_frequent(&self) -> bool {
+        self.hours.is_all()
+            || self.minutes.ordinals().len() > 1
+            || self.seconds.ordinals().len() > 1
     }
 
     pub(crate) fn days_of_week_is_all(&self) -> bool {

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -41,10 +41,11 @@ impl Schedule {
         Schedule::builder()
     }
 
-    /// Returns a parser builder configured for Vixie day-of-week numbering (0-6).
+    /// Returns a parser builder configured for Vixie cron behavior.
     pub fn vixie() -> ScheduleConfigBuilder {
         Schedule::builder()
-            .day_of_week_numbering(DayOfWeekNumbering::ZeroToSix)
+            .day_of_week_numbering(DayOfWeekNumbering::ZeroIndexed)
+            .wraparound_ranges(true)
             .dow_dom_operand(DowDomOperand::Or)
     }
 
@@ -301,6 +302,11 @@ impl ScheduleConfigBuilder {
 
     pub fn day_of_week_numbering(mut self, numbering: DayOfWeekNumbering) -> Self {
         self.config.day_of_week_numbering = numbering;
+        self
+    }
+
+    pub fn wraparound_ranges(mut self, wraparound_ranges: bool) -> Self {
+        self.config.wraparound_ranges = wraparound_ranges;
         self
     }
 

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -1,5 +1,7 @@
-use chrono::offset::{LocalResult, TimeZone};
-use chrono::{DateTime, Datelike, TimeDelta, Timelike, Utc};
+use chrono::offset::{LocalResult, Offset, TimeZone};
+use chrono::{DateTime, Datelike, NaiveDate, NaiveDateTime, NaiveTime, TimeDelta, Timelike, Utc};
+use chrono_tz::GapInfo;
+use std::any::Any;
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
 #[cfg(feature = "serde")]
@@ -14,7 +16,13 @@ use crate::error::Error;
 use crate::ordinal::*;
 use crate::queries::*;
 use crate::time_unit::*;
-use crate::{CronScheduleParts, DayOfWeekNumbering, DowDomOperand, ScheduleConfig};
+use crate::{
+    CronScheduleParts, DayOfWeekNumbering, DowDomOperand, NonexistentTimeBehavior, ScheduleConfig,
+};
+
+// This is an offset probe, not the local gap search span. A nonexistent local
+// time's corresponding UTC transition can be shifted by the zone's UTC offset.
+const NONEXISTENT_OFFSET_PROBE_SECONDS: i64 = 18 * 60 * 60;
 
 impl From<Schedule> for String {
     fn from(schedule: Schedule) -> String {
@@ -59,21 +67,21 @@ impl Schedule {
 
     fn next_after<Z>(&self, after: &DateTime<Z>) -> Option<DateTime<Z>>
     where
-        Z: TimeZone,
+        Z: TimeZone + 'static,
     {
         self.find_with_query(NextAfterQuery::from(after), after)
     }
 
     fn prev_from<Z>(&self, before: &DateTime<Z>) -> Option<DateTime<Z>>
     where
-        Z: TimeZone,
+        Z: TimeZone + 'static,
     {
         self.find_with_query(PrevFromQuery::from(before), before)
     }
 
     fn find_with_query<Z, Q>(&self, mut query: Q, datetime: &DateTime<Z>) -> Option<DateTime<Z>>
     where
-        Z: TimeZone,
+        Z: TimeZone + 'static,
         Q: Query<Z>,
     {
         let mut deferred_candidate: Option<DateTime<Z>> = None;
@@ -106,7 +114,44 @@ impl Schedule {
                                     *second,
                                 );
                                 match local_result {
-                                    LocalResult::None => continue,
+                                    LocalResult::None => {
+                                        if self.config.nonexistent_time_behavior
+                                            == NonexistentTimeBehavior::Skip
+                                        {
+                                            continue;
+                                        }
+
+                                        let Some(candidate) = next_existent_datetime(
+                                            &datetime.timezone(),
+                                            NaiveDateTime::new(
+                                                NaiveDate::from_ymd_opt(
+                                                    *year as i32,
+                                                    *month,
+                                                    day_of_month,
+                                                )?,
+                                                NaiveTime::from_hms_opt(*hour, *minute, *second)?,
+                                            ),
+                                        ) else {
+                                            continue;
+                                        };
+
+                                        if !query.preceeds_reference_datetime(&candidate) {
+                                            continue;
+                                        }
+                                        if !self.within_search_interval(
+                                            datetime,
+                                            &candidate,
+                                            query.is_reversed(),
+                                        ) {
+                                            return deferred_candidate;
+                                        }
+                                        if let Some(deferred) = deferred_candidate.take() {
+                                            return Some(
+                                                query.preferred_candidate(deferred, candidate),
+                                            );
+                                        }
+                                        return Some(candidate);
+                                    }
                                     LocalResult::Single(candidate) => {
                                         if !query.preceeds_reference_datetime(&candidate) {
                                             continue;
@@ -179,26 +224,29 @@ impl Schedule {
     /// the current time if applicable.
     pub fn upcoming<Z>(&self, timezone: Z) -> ScheduleIterator<'_, Z>
     where
-        Z: TimeZone,
+        Z: TimeZone + 'static,
     {
         self.after(&timezone.from_utc_datetime(&Utc::now().naive_utc()))
     }
 
     /// The same, but with an iterator with a static ownership
-    pub fn upcoming_owned<Z: TimeZone>(&self, timezone: Z) -> OwnedScheduleIterator<Z> {
+    pub fn upcoming_owned<Z: TimeZone + 'static>(&self, timezone: Z) -> OwnedScheduleIterator<Z> {
         self.after_owned(timezone.from_utc_datetime(&Utc::now().naive_utc()))
     }
 
     /// Like the `upcoming` method, but allows you to specify a start time other than the present.
     pub fn after<Z>(&self, after: &DateTime<Z>) -> ScheduleIterator<'_, Z>
     where
-        Z: TimeZone,
+        Z: TimeZone + 'static,
     {
         ScheduleIterator::new(self, after)
     }
 
     /// The same, but with a static ownership.
-    pub fn after_owned<Z: TimeZone>(&self, after: DateTime<Z>) -> OwnedScheduleIterator<Z> {
+    pub fn after_owned<Z: TimeZone + 'static>(
+        &self,
+        after: DateTime<Z>,
+    ) -> OwnedScheduleIterator<Z> {
         OwnedScheduleIterator::new(self.clone(), after)
     }
 
@@ -324,12 +372,133 @@ impl ScheduleConfigBuilder {
         self
     }
 
+    pub fn nonexistent_time_behavior(mut self, behavior: NonexistentTimeBehavior) -> Self {
+        self.config.nonexistent_time_behavior = behavior;
+        self
+    }
+
     pub fn parse(self, expression: &str) -> Result<Schedule, Error> {
         Schedule::from_str_with_config(expression, self.config)
     }
 
     pub fn config(&self) -> ScheduleConfig {
         self.config
+    }
+}
+
+fn next_existent_datetime<Z>(timezone: &Z, nonexistent: NaiveDateTime) -> Option<DateTime<Z>>
+where
+    Z: TimeZone + 'static,
+{
+    if let Some(candidate) = next_existent_chrono_tz_datetime(timezone, nonexistent) {
+        return Some(candidate);
+    }
+
+    let before_probe =
+        nonexistent.checked_sub_signed(TimeDelta::seconds(NONEXISTENT_OFFSET_PROBE_SECONDS))?;
+    let after_probe =
+        nonexistent.checked_add_signed(TimeDelta::seconds(NONEXISTENT_OFFSET_PROBE_SECONDS))?;
+    let before_offset = timezone
+        .offset_from_utc_datetime(&before_probe)
+        .fix()
+        .local_minus_utc();
+    let after_offset = timezone
+        .offset_from_utc_datetime(&after_probe)
+        .fix()
+        .local_minus_utc();
+
+    // A nonexistent local time should come from a forward offset transition. If the generic
+    // fallback cannot observe that across its probes, it cannot infer the gap boundary.
+    if after_offset <= before_offset {
+        return None;
+    }
+
+    let mut lower = nonexistent.checked_sub_signed(TimeDelta::seconds(i64::from(after_offset)))?;
+    let mut upper = nonexistent.checked_sub_signed(TimeDelta::seconds(i64::from(before_offset)))?;
+    let upper_local = timezone.from_utc_datetime(&upper).naive_local();
+
+    if let Some(candidate) = likely_gap_end_datetime(timezone, nonexistent, upper_local) {
+        return Some(candidate);
+    }
+
+    // Chrono's generic `TimeZone` exposes offsets but not transition tables. For a forward
+    // transition, the surrounding offsets bracket the UTC instant where local time jumps over
+    // `nonexistent`, so search that small UTC interval for the first existent local time after it.
+    while upper.signed_duration_since(lower) > TimeDelta::seconds(1) {
+        let midpoint = lower.checked_add_signed(upper.signed_duration_since(lower) / 2)?;
+        if timezone.from_utc_datetime(&midpoint).naive_local() > nonexistent {
+            upper = midpoint;
+        } else {
+            lower = midpoint;
+        }
+    }
+
+    let candidate = timezone.from_utc_datetime(&upper);
+    (candidate.naive_local() > nonexistent).then_some(candidate)
+}
+
+fn next_existent_chrono_tz_datetime<Z>(
+    timezone: &Z,
+    nonexistent: NaiveDateTime,
+) -> Option<DateTime<Z>>
+where
+    Z: TimeZone + 'static,
+{
+    // `chrono_tz::Tz` exposes transition metadata, but stable Rust cannot specialize the generic
+    // `TimeZone` path. Use a safe runtime downcast when the concrete timezone is exactly `Tz`.
+    let chrono_tz = (timezone as &dyn Any).downcast_ref::<chrono_tz::Tz>()?;
+    GapInfo::new(&nonexistent, chrono_tz)?
+        .end
+        .map(|candidate| candidate.with_timezone(timezone))
+}
+
+fn likely_gap_end_datetime<Z>(
+    timezone: &Z,
+    nonexistent: NaiveDateTime,
+    upper_local: NaiveDateTime,
+) -> Option<DateTime<Z>>
+where
+    Z: TimeZone,
+{
+    for interval_seconds in [60 * 60, 15 * 60] {
+        let mut boundary = next_local_boundary(nonexistent, interval_seconds)?;
+        while boundary <= upper_local {
+            if let Some(candidate) = gap_end_at_boundary(timezone, boundary) {
+                return Some(candidate);
+            }
+            boundary = boundary.checked_add_signed(TimeDelta::seconds(interval_seconds))?;
+        }
+    }
+
+    None
+}
+
+fn next_local_boundary(datetime: NaiveDateTime, interval_seconds: i64) -> Option<NaiveDateTime> {
+    let day_start = datetime.date().and_hms_opt(0, 0, 0)?;
+    let seconds_from_midnight = i64::from(datetime.time().num_seconds_from_midnight());
+    let next_boundary_seconds = ((seconds_from_midnight / interval_seconds) + 1) * interval_seconds;
+
+    day_start.checked_add_signed(TimeDelta::seconds(next_boundary_seconds))
+}
+
+fn gap_end_at_boundary<Z>(timezone: &Z, boundary: NaiveDateTime) -> Option<DateTime<Z>>
+where
+    Z: TimeZone,
+{
+    let previous_second = boundary.checked_sub_signed(TimeDelta::seconds(1))?;
+    if !matches!(
+        timezone.from_local_datetime(&previous_second),
+        LocalResult::None
+    ) {
+        return None;
+    }
+
+    match timezone.from_local_datetime(&boundary) {
+        LocalResult::Single(candidate) => Some(candidate),
+        LocalResult::Ambiguous(earlier, later) => {
+            Some(if earlier < later { earlier } else { later })
+        }
+        LocalResult::None => None,
     }
 }
 
@@ -439,7 +608,7 @@ impl ScheduleFields {
 
 pub struct ScheduleIterator<'a, Z>
 where
-    Z: TimeZone,
+    Z: TimeZone + 'static,
 {
     schedule: &'a Schedule,
     previous_datetime: Option<DateTime<Z>>,
@@ -448,7 +617,7 @@ where
 
 impl<'a, Z> ScheduleIterator<'a, Z>
 where
-    Z: TimeZone,
+    Z: TimeZone + 'static,
 {
     fn new(schedule: &'a Schedule, starting_datetime: &DateTime<Z>) -> Self {
         ScheduleIterator {
@@ -460,7 +629,7 @@ where
 
 impl<Z> Iterator for ScheduleIterator<'_, Z>
 where
-    Z: TimeZone,
+    Z: TimeZone + 'static,
 {
     type Item = DateTime<Z>;
 
@@ -475,7 +644,7 @@ where
 
 impl<Z> DoubleEndedIterator for ScheduleIterator<'_, Z>
 where
-    Z: TimeZone,
+    Z: TimeZone + 'static,
 {
     fn next_back(&mut self) -> Option<Self::Item> {
         let previous = self.previous_datetime.take()?;
@@ -489,7 +658,7 @@ where
 /// A `ScheduleIterator` with a static lifetime.
 pub struct OwnedScheduleIterator<Z>
 where
-    Z: TimeZone,
+    Z: TimeZone + 'static,
 {
     schedule: Schedule,
     previous_datetime: Option<DateTime<Z>>,
@@ -497,7 +666,7 @@ where
 
 impl<Z> OwnedScheduleIterator<Z>
 where
-    Z: TimeZone,
+    Z: TimeZone + 'static,
 {
     pub fn new(schedule: Schedule, starting_datetime: DateTime<Z>) -> Self {
         Self {
@@ -509,7 +678,7 @@ where
 
 impl<Z> Iterator for OwnedScheduleIterator<Z>
 where
-    Z: TimeZone,
+    Z: TimeZone + 'static,
 {
     type Item = DateTime<Z>;
 
@@ -522,7 +691,7 @@ where
     }
 }
 
-impl<Z: TimeZone> DoubleEndedIterator for OwnedScheduleIterator<Z> {
+impl<Z: TimeZone + 'static> DoubleEndedIterator for OwnedScheduleIterator<Z> {
     fn next_back(&mut self) -> Option<Self::Item> {
         let previous = self.previous_datetime.take()?;
 
@@ -868,6 +1037,23 @@ mod test {
         let schedule = Schedule::from_str("* * * * * Sat,Sun *").unwrap();
         let prev = schedule.after(&dt).nth_back(1).unwrap();
         assert!(prev < dt); // test is ensuring line above does not panic
+    }
+
+    #[test]
+    fn test_chrono_tz_next_existent_fast_path() {
+        use chrono::NaiveDate;
+        use chrono_tz::America::Los_Angeles;
+
+        let nonexistent = NaiveDate::from_ymd_opt(2022, 3, 13)
+            .unwrap()
+            .and_hms_opt(2, 30, 0)
+            .unwrap();
+        let candidate = next_existent_chrono_tz_datetime(&Los_Angeles, nonexistent).unwrap();
+
+        assert_eq!(
+            candidate,
+            Los_Angeles.with_ymd_and_hms(2022, 3, 13, 3, 0, 0).unwrap()
+        );
     }
 
     #[test]

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -92,21 +92,21 @@ impl Schedule {
             }
             _ => false,
         };
-        for year in query.years(&self.fields) {
-            for month in query.months(&self.fields, *year) {
+        for year in query.years(&self.fields, self.config.search_interval) {
+            for month in query.months(&self.fields, year) {
                 for day_of_month in
-                    query.days_of_month(&self.fields, *year, *month, self.config.dow_dom_operand)
+                    query.days_of_month(&self.fields, year, *month, self.config.dow_dom_operand)
                 {
                     for hour in query.hours(&self.fields) {
                         let fold_hour_scan = fold_scan_active
-                            && *year as i32 == reference_naive.year()
+                            && year as i32 == reference_naive.year()
                             && *month == reference_naive.month()
                             && day_of_month == reference_naive.day()
                             && *hour == reference_naive.hour();
                         for minute in query.minutes(&self.fields, fold_hour_scan) {
                             for second in query.seconds(&self.fields, fold_hour_scan) {
                                 let local_result = datetime.timezone().with_ymd_and_hms(
-                                    *year as i32,
+                                    year as i32,
                                     *month,
                                     day_of_month,
                                     *hour,
@@ -126,7 +126,7 @@ impl Schedule {
                                             &datetime.timezone(),
                                             NaiveDateTime::new(
                                                 NaiveDate::from_ymd_opt(
-                                                    *year as i32,
+                                                    year as i32,
                                                     *month,
                                                     day_of_month,
                                                 )?,
@@ -257,7 +257,7 @@ impl Schedule {
     {
         let day_of_month = date_time.day() as Ordinal;
         let day_of_week = date_time.weekday().number_from_sunday();
-        self.fields.years.includes(date_time.year() as Ordinal)
+        self.fields.includes_year(date_time.year() as Ordinal)
             && self.fields.months.includes(date_time.month() as Ordinal)
             && self
                 .fields
@@ -547,8 +547,20 @@ impl ScheduleFields {
         }
     }
 
-    pub(crate) fn years_ordinals(&self) -> &OrdinalSet {
-        self.years.ordinals()
+    pub(crate) fn years_are_unrestricted(&self) -> bool {
+        self.years.is_unrestricted()
+    }
+
+    pub(crate) fn includes_year(&self, year: Ordinal) -> bool {
+        self.years.contains_ordinal(year)
+    }
+
+    pub(crate) fn years_between(
+        &self,
+        start: Ordinal,
+        end: Ordinal,
+    ) -> impl DoubleEndedIterator<Item = Ordinal> + '_ {
+        self.years.ordinals_between(start, end)
     }
 
     pub(crate) fn months_ordinals(&self) -> &OrdinalSet {
@@ -798,9 +810,7 @@ mod test {
             &[Token::String(
                 "definitively an invalid value for a cron schedule!",
             )],
-            "definitively an invalid value for a cron schedule!\n\
-                ^\n\
-                The 'Seconds' field does not support using names. 'definitively' specified.",
+            "a valid cron expression",
         );
     }
 
@@ -1066,7 +1076,7 @@ mod test {
     #[test]
     fn test_no_panic_on_leap_day_time_after() {
         let dt = chrono::DateTime::parse_from_rfc3339("2024-02-29T10:00:00.000+08:00").unwrap();
-        let schedule = Schedule::from_str("0 0 0 * * * 2100").unwrap();
+        let schedule = Schedule::from_str("0 0 0 * * * 2099").unwrap();
         let next = schedule.after(&dt).next().unwrap();
         assert!(next > dt); // test is ensuring line above does not panic
     }

--- a/src/specifier.rs
+++ b/src/specifier.rs
@@ -1,7 +1,7 @@
 use crate::ordinal::*;
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum RangeEndpoint {
     Ordinal(Ordinal),
     Name(String),
@@ -16,7 +16,7 @@ impl Display for RangeEndpoint {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Specifier {
     All,
     Point(Ordinal),
@@ -30,7 +30,7 @@ pub enum Specifier {
 // - named range: 'Mon-Thurs/2'
 //
 // Without this separation we would end up with invalid combinations such as 'Mon/2'
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum RootSpecifier {
     Specifier(Specifier),
     Period(Specifier, u32),

--- a/src/specifier.rs
+++ b/src/specifier.rs
@@ -1,11 +1,26 @@
 use crate::ordinal::*;
+use std::fmt::{Display, Formatter, Result as FmtResult};
+
+#[derive(Debug, PartialEq)]
+pub enum RangeEndpoint {
+    Ordinal(Ordinal),
+    Name(String),
+}
+
+impl Display for RangeEndpoint {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            Self::Ordinal(ordinal) => write!(f, "{ordinal}"),
+            Self::Name(name) => write!(f, "{name}"),
+        }
+    }
+}
 
 #[derive(Debug, PartialEq)]
 pub enum Specifier {
     All,
     Point(Ordinal),
-    Range(Ordinal, Ordinal),
-    NamedRange(String, String),
+    Range(RangeEndpoint, RangeEndpoint),
 }
 
 // Separating out a root specifier allows for a higher tiered specifier, allowing us to achieve

--- a/src/time_unit/mod.rs
+++ b/src/time_unit/mod.rs
@@ -177,7 +177,7 @@ where
     T: TimeUnitField,
 {
     fn includes(&self, ordinal: Ordinal) -> bool {
-        self.ordinals().contains(&ordinal)
+        self.contains_ordinal(ordinal)
     }
     fn iter(&self) -> OrdinalIter<'_> {
         OrdinalIter {
@@ -197,8 +197,7 @@ where
     }
 
     fn is_all(&self) -> bool {
-        let max_supported_ordinals = Self::inclusive_max() - Self::inclusive_min() + 1;
-        self.ordinals().len() == max_supported_ordinals as usize
+        self.has_all_ordinals()
     }
 }
 
@@ -271,6 +270,15 @@ where
     fn inclusive_min() -> Ordinal;
     fn inclusive_max() -> Ordinal;
     fn ordinals(&self) -> &OrdinalSet;
+
+    fn contains_ordinal(&self, ordinal: Ordinal) -> bool {
+        self.ordinals().contains(&ordinal)
+    }
+
+    fn has_all_ordinals(&self) -> bool {
+        let max_supported_ordinals = Self::inclusive_max() - Self::inclusive_min() + 1;
+        self.ordinals().len() == max_supported_ordinals as usize
+    }
 
     fn from_ordinal(ordinal: Ordinal) -> Self {
         Self::from_ordinal_set(iter::once(ordinal).collect())

--- a/src/time_unit/mod.rs
+++ b/src/time_unit/mod.rs
@@ -209,10 +209,54 @@ pub(crate) fn ordinal_range_values(
     inclusive_max: Ordinal,
     wraparound_ranges: bool,
 ) -> Option<Vec<Ordinal>> {
-    if start <= end {
-        Some((start..=end).collect())
+    ordinal_range_values_with_step(
+        start,
+        end,
+        inclusive_min,
+        inclusive_max,
+        wraparound_ranges,
+        1,
+    )
+}
+
+pub(crate) fn ordinal_range_values_with_step(
+    start: Ordinal,
+    end: Ordinal,
+    inclusive_min: Ordinal,
+    inclusive_max: Ordinal,
+    wraparound_ranges: bool,
+    step: Ordinal,
+) -> Option<Vec<Ordinal>> {
+    let step = step as usize;
+
+    if wraparound_ranges && start == end {
+        Some((inclusive_min..=inclusive_max).step_by(step).collect())
+    } else if start <= end {
+        Some((start..=end).step_by(step).collect())
     } else if wraparound_ranges {
-        Some((start..=inclusive_max).chain(inclusive_min..=end).collect())
+        let first_segment = (start..=inclusive_max).step_by(step).collect::<Vec<_>>();
+        // Croniter preserves the original range step across the max-to-min boundary by
+        // skipping initial wrapped values when the first segment lands near the field max.
+        let to_skip = first_segment
+            .last()
+            .map(|last| {
+                let step = step as Ordinal;
+                let already_skipped = inclusive_max - last;
+                let current_position = last - inclusive_min;
+                let field_len = inclusive_max - inclusive_min + 1;
+                if current_position + step > field_len && already_skipped < step {
+                    step - already_skipped
+                } else {
+                    0
+                }
+            })
+            .unwrap_or(0);
+        Some(
+            first_segment
+                .into_iter()
+                .chain(((inclusive_min + to_skip)..=end).step_by(step))
+                .collect(),
+        )
     } else {
         None
     }
@@ -363,6 +407,30 @@ where
                     Specifier::Point(start) => {
                         let start = Self::validate_ordinal(*start)?;
                         (start..=Self::inclusive_max()).collect()
+                    }
+                    Specifier::Range(start, end) => {
+                        let start_ordinal =
+                            Self::validate_ordinal(Self::ordinal_from_range_endpoint(start)?)?;
+                        let end_ordinal =
+                            Self::validate_ordinal(Self::ordinal_from_range_endpoint(end)?)?;
+                        return ordinal_range_values_with_step(
+                            start_ordinal,
+                            end_ordinal,
+                            Self::inclusive_min(),
+                            Self::inclusive_max(),
+                            wraparound_ranges,
+                            *step,
+                        )
+                        .map(|ordinals| ordinals.into_iter().collect())
+                        .ok_or_else(|| {
+                            ErrorKind::Expression(format!(
+                                "Invalid range for {}: {}-{}",
+                                Self::name(),
+                                start,
+                                end
+                            ))
+                            .into()
+                        });
                     }
                     specifier => Self::ordinal_values_from_specifier_with_options(
                         specifier,

--- a/src/time_unit/mod.rs
+++ b/src/time_unit/mod.rs
@@ -16,7 +16,7 @@ pub use self::years::Years;
 
 use crate::error::*;
 use crate::ordinal::{Ordinal, OrdinalSet};
-use crate::specifier::{RootSpecifier, Specifier};
+use crate::specifier::{RangeEndpoint, RootSpecifier, Specifier};
 use std::borrow::Cow;
 use std::collections::btree_set;
 use std::iter;
@@ -202,6 +202,22 @@ where
     }
 }
 
+pub(crate) fn ordinal_range_values(
+    start: Ordinal,
+    end: Ordinal,
+    inclusive_min: Ordinal,
+    inclusive_max: Ordinal,
+    wraparound_ranges: bool,
+) -> Option<Vec<Ordinal>> {
+    if start <= end {
+        Some((start..=end).collect())
+    } else if wraparound_ranges {
+        Some((start..=inclusive_max).chain(inclusive_min..=end).collect())
+    } else {
+        None
+    }
+}
+
 pub trait TimeUnitField
 where
     Self: Sized,
@@ -237,6 +253,14 @@ where
         ))
         .into())
     }
+
+    fn ordinal_from_range_endpoint(endpoint: &RangeEndpoint) -> Result<Ordinal, Error> {
+        match endpoint {
+            RangeEndpoint::Ordinal(ordinal) => Ok(*ordinal),
+            RangeEndpoint::Name(name) => Self::ordinal_from_name(name),
+        }
+    }
+
     fn validate_ordinal(ordinal: Ordinal) -> Result<Ordinal, Error> {
         //println!("validate_ordinal for {} => {}", Self::name(), ordinal);
         match ordinal {
@@ -260,43 +284,65 @@ where
     }
 
     fn ordinals_from_specifier(specifier: &Specifier) -> Result<OrdinalSet, Error> {
+        Self::ordinals_from_specifier_with_options(specifier, false)
+    }
+
+    fn ordinal_values_from_specifier_with_options(
+        specifier: &Specifier,
+        wraparound_ranges: bool,
+    ) -> Result<Vec<Ordinal>, Error> {
         use self::Specifier::*;
         //println!("ordinals_from_specifier for {} => {:?}", Self::name(), specifier);
-        match *specifier {
-            All => Ok(Self::supported_ordinals()),
-            Point(ordinal) => Ok(([ordinal]).iter().cloned().collect()),
+        match specifier {
+            All => Ok((Self::inclusive_min()..=Self::inclusive_max()).collect()),
+            Point(ordinal) => Ok(vec![Self::validate_ordinal(*ordinal)?]),
             Range(start, end) => {
-                match (Self::validate_ordinal(start), Self::validate_ordinal(end)) {
-                    (Ok(start), Ok(end)) if start <= end => Ok((start..end + 1).collect()),
-                    _ => Err(ErrorKind::Expression(format!(
+                let start_ordinal =
+                    Self::validate_ordinal(Self::ordinal_from_range_endpoint(start)?)?;
+                let end_ordinal = Self::validate_ordinal(Self::ordinal_from_range_endpoint(end)?)?;
+                ordinal_range_values(
+                    start_ordinal,
+                    end_ordinal,
+                    Self::inclusive_min(),
+                    Self::inclusive_max(),
+                    wraparound_ranges,
+                )
+                .ok_or_else(|| {
+                    ErrorKind::Expression(format!(
                         "Invalid range for {}: {}-{}",
                         Self::name(),
                         start,
                         end
                     ))
-                    .into()),
-                }
-            }
-            NamedRange(ref start_name, ref end_name) => {
-                let start = Self::ordinal_from_name(start_name)?;
-                let end = Self::ordinal_from_name(end_name)?;
-                match (Self::validate_ordinal(start), Self::validate_ordinal(end)) {
-                    (Ok(start), Ok(end)) if start <= end => Ok((start..end + 1).collect()),
-                    _ => Err(ErrorKind::Expression(format!(
-                        "Invalid named range for {}: {}-{}",
-                        Self::name(),
-                        start_name,
-                        end_name
-                    ))
-                    .into()),
-                }
+                    .into()
+                })
             }
         }
     }
 
+    fn ordinals_from_specifier_with_options(
+        specifier: &Specifier,
+        wraparound_ranges: bool,
+    ) -> Result<OrdinalSet, Error> {
+        Ok(
+            Self::ordinal_values_from_specifier_with_options(specifier, wraparound_ranges)?
+                .into_iter()
+                .collect(),
+        )
+    }
+
     fn ordinals_from_root_specifier(root_specifier: &RootSpecifier) -> Result<OrdinalSet, Error> {
+        Self::ordinals_from_root_specifier_with_options(root_specifier, false)
+    }
+
+    fn ordinals_from_root_specifier_with_options(
+        root_specifier: &RootSpecifier,
+        wraparound_ranges: bool,
+    ) -> Result<OrdinalSet, Error> {
         let ordinals = match root_specifier {
-            RootSpecifier::Specifier(specifier) => Self::ordinals_from_specifier(specifier)?,
+            RootSpecifier::Specifier(specifier) => {
+                Self::ordinals_from_specifier_with_options(specifier, wraparound_ranges)?
+            }
             RootSpecifier::Period(_, 0) => Err(ErrorKind::Expression(
                 "range step cannot be zero".to_string(),
             ))?,
@@ -311,16 +357,19 @@ where
                     .into());
                 }
 
-                let base_set = match start {
+                let base_values = match start {
                     // A point prior to a period implies a range whose start is the specified
                     // point and terminating inclusively with the inclusive max
                     Specifier::Point(start) => {
                         let start = Self::validate_ordinal(*start)?;
                         (start..=Self::inclusive_max()).collect()
                     }
-                    specifier => Self::ordinals_from_specifier(specifier)?,
+                    specifier => Self::ordinal_values_from_specifier_with_options(
+                        specifier,
+                        wraparound_ranges,
+                    )?,
                 };
-                base_set.into_iter().step_by(*step as usize).collect()
+                base_values.into_iter().step_by(*step as usize).collect()
             }
             RootSpecifier::NamedPoint(ref name) => ([Self::ordinal_from_name(name)?])
                 .iter()

--- a/src/time_unit/years.rs
+++ b/src/time_unit/years.rs
@@ -1,43 +1,320 @@
+use crate::error::{Error, ErrorKind};
 use crate::ordinal::{Ordinal, OrdinalSet};
+use crate::specifier::{RangeEndpoint, RootSpecifier, Specifier};
 use crate::time_unit::TimeUnitField;
 use once_cell::sync::Lazy;
 use std::borrow::Cow;
 
-static ALL: Lazy<OrdinalSet> = Lazy::new(Years::supported_ordinals);
+const FIRST_YEAR: Ordinal = 0;
+const LAST_YEAR: Ordinal = i32::MAX as Ordinal;
+const MAX_MATERIALIZED_YEARS: Ordinal = 10_000;
 
-#[derive(Clone, Debug, Eq)]
+static EMPTY: Lazy<OrdinalSet> = Lazy::new(OrdinalSet::new);
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum YearsSpec {
+    All,
+    Ordinals(OrdinalSet),
+    Predicates {
+        specifiers: Vec<RootSpecifier>,
+        wraparound_ranges: bool,
+    },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Years {
-    ordinals: Option<OrdinalSet>,
+    spec: YearsSpec,
 }
 
 impl TimeUnitField for Years {
     fn from_optional_ordinal_set(ordinal_set: Option<OrdinalSet>) -> Self {
         Years {
-            ordinals: ordinal_set,
+            spec: ordinal_set.map_or(YearsSpec::All, YearsSpec::Ordinals),
         }
     }
+
     fn name() -> Cow<'static, str> {
         Cow::from("Years")
     }
 
-    // TODO: Using the default impl, this will make a set w/100+ items each time "*" is used.
-    // This is obviously suboptimal.
     fn inclusive_min() -> Ordinal {
-        1970
+        FIRST_YEAR
     }
+
     fn inclusive_max() -> Ordinal {
-        2100
+        LAST_YEAR
     }
+
     fn ordinals(&self) -> &OrdinalSet {
-        match &self.ordinals {
-            Some(ordinal_set) => ordinal_set,
-            None => &ALL,
+        match &self.spec {
+            YearsSpec::Ordinals(ordinals) => ordinals,
+            YearsSpec::All | YearsSpec::Predicates { .. } => &EMPTY,
+        }
+    }
+
+    fn contains_ordinal(&self, ordinal: Ordinal) -> bool {
+        match &self.spec {
+            YearsSpec::All => ordinal <= LAST_YEAR,
+            YearsSpec::Ordinals(ordinals) => ordinals.contains(&ordinal),
+            YearsSpec::Predicates {
+                specifiers,
+                wraparound_ranges,
+            } => {
+                ordinal <= LAST_YEAR
+                    && specifiers
+                        .iter()
+                        .any(|specifier| root_contains(specifier, ordinal, *wraparound_ranges))
+            }
+        }
+    }
+
+    fn has_all_ordinals(&self) -> bool {
+        matches!(self.spec, YearsSpec::All)
+    }
+}
+
+impl Years {
+    pub(crate) fn from_root_specifiers(
+        specifiers: Vec<RootSpecifier>,
+        wraparound_ranges: bool,
+    ) -> Result<Self, Error> {
+        validate_root_specifiers(&specifiers, wraparound_ranges)?;
+
+        if specifiers
+            .iter()
+            .any(|specifier| matches!(specifier, RootSpecifier::Specifier(Specifier::All)))
+        {
+            return Ok(Self::all());
+        }
+
+        if let Some(ordinals) = materialize_ordinals(&specifiers, wraparound_ranges) {
+            return Ok(Self::from_ordinal_set(ordinals));
+        }
+
+        Ok(Years {
+            spec: YearsSpec::Predicates {
+                specifiers,
+                wraparound_ranges,
+            },
+        })
+    }
+
+    pub(crate) fn is_unrestricted(&self) -> bool {
+        matches!(self.spec, YearsSpec::All)
+    }
+
+    pub(crate) fn ordinals_between(
+        &self,
+        start: Ordinal,
+        end: Ordinal,
+    ) -> Box<dyn DoubleEndedIterator<Item = Ordinal> + '_> {
+        let end = end.min(LAST_YEAR);
+        if start > end {
+            return Box::new(std::iter::empty());
+        }
+
+        match &self.spec {
+            YearsSpec::All => Box::new(start..=end),
+            YearsSpec::Ordinals(ordinals) => Box::new(ordinals.range(start..=end).copied()),
+            YearsSpec::Predicates { .. } => {
+                Box::new((start..=end).filter(move |year| self.contains_ordinal(*year)))
+            }
         }
     }
 }
 
-impl PartialEq for Years {
-    fn eq(&self, other: &Years) -> bool {
-        self.ordinals() == other.ordinals()
+fn validate_root_specifiers(
+    specifiers: &[RootSpecifier],
+    wraparound_ranges: bool,
+) -> Result<(), Error> {
+    for specifier in specifiers {
+        match specifier {
+            RootSpecifier::Specifier(specifier) => {
+                validate_specifier(specifier, wraparound_ranges)?
+            }
+            RootSpecifier::Period(_, 0) => {
+                return Err(ErrorKind::Expression("range step cannot be zero".to_string()).into());
+            }
+            RootSpecifier::Period(specifier, _) => {
+                validate_specifier(specifier, wraparound_ranges)?
+            }
+            RootSpecifier::NamedPoint(name) => {
+                Years::ordinal_from_name(name)?;
+            }
+        }
     }
+    Ok(())
+}
+
+fn validate_specifier(specifier: &Specifier, wraparound_ranges: bool) -> Result<(), Error> {
+    match specifier {
+        Specifier::All => Ok(()),
+        Specifier::Point(ordinal) => {
+            Years::validate_ordinal(*ordinal)?;
+            Ok(())
+        }
+        Specifier::Range(start, end) => {
+            let start = Years::validate_ordinal(ordinal_from_endpoint(start)?)?;
+            let end = Years::validate_ordinal(ordinal_from_endpoint(end)?)?;
+            if start > end && !wraparound_ranges {
+                return Err(ErrorKind::Expression(format!(
+                    "Invalid range for Years: {}-{}",
+                    start, end
+                ))
+                .into());
+            }
+            Ok(())
+        }
+    }
+}
+
+fn ordinal_from_endpoint(endpoint: &RangeEndpoint) -> Result<Ordinal, Error> {
+    match endpoint {
+        RangeEndpoint::Ordinal(ordinal) => Ok(*ordinal),
+        RangeEndpoint::Name(name) => Years::ordinal_from_name(name),
+    }
+}
+
+fn materialize_ordinals(
+    specifiers: &[RootSpecifier],
+    wraparound_ranges: bool,
+) -> Option<OrdinalSet> {
+    let mut ordinals = OrdinalSet::new();
+    for specifier in specifiers {
+        ordinals.extend(materialize_root_specifier(specifier, wraparound_ranges)?);
+    }
+    Some(ordinals)
+}
+
+fn materialize_root_specifier(
+    root_specifier: &RootSpecifier,
+    wraparound_ranges: bool,
+) -> Option<Vec<Ordinal>> {
+    match root_specifier {
+        RootSpecifier::Specifier(specifier) => materialize_specifier(specifier, wraparound_ranges),
+        RootSpecifier::Period(Specifier::Range(start, end), step) => {
+            let start = ordinal_from_endpoint(start).ok()?;
+            let end = ordinal_from_endpoint(end).ok()?;
+            let len = years_in_range(start, end);
+            if (wraparound_ranges && start >= end) || len > MAX_MATERIALIZED_YEARS {
+                return None;
+            }
+            Some((start..=end).step_by(*step as usize).collect())
+        }
+        RootSpecifier::Period(_, _) | RootSpecifier::NamedPoint(_) => None,
+    }
+}
+
+fn materialize_specifier(specifier: &Specifier, wraparound_ranges: bool) -> Option<Vec<Ordinal>> {
+    match specifier {
+        Specifier::All => None,
+        Specifier::Point(ordinal) => Some(vec![*ordinal]),
+        Specifier::Range(start, end) => {
+            let start = ordinal_from_endpoint(start).ok()?;
+            let end = ordinal_from_endpoint(end).ok()?;
+            let len = years_in_range(start, end);
+            if (wraparound_ranges && start >= end) || len > MAX_MATERIALIZED_YEARS {
+                return None;
+            }
+            Some((start..=end).collect())
+        }
+    }
+}
+
+fn years_in_range(start: Ordinal, end: Ordinal) -> Ordinal {
+    end.saturating_sub(start).saturating_add(1)
+}
+
+fn root_contains(
+    root_specifier: &RootSpecifier,
+    ordinal: Ordinal,
+    wraparound_ranges: bool,
+) -> bool {
+    match root_specifier {
+        RootSpecifier::Specifier(specifier) => {
+            specifier_contains(specifier, ordinal, wraparound_ranges)
+        }
+        RootSpecifier::Period(specifier, step) => {
+            period_contains(specifier, ordinal, *step, wraparound_ranges)
+        }
+        RootSpecifier::NamedPoint(_) => false,
+    }
+}
+
+fn specifier_contains(specifier: &Specifier, ordinal: Ordinal, wraparound_ranges: bool) -> bool {
+    match specifier {
+        Specifier::All => true,
+        Specifier::Point(point) => ordinal == *point,
+        Specifier::Range(start, end) => {
+            let (Ok(start), Ok(end)) = (ordinal_from_endpoint(start), ordinal_from_endpoint(end))
+            else {
+                return false;
+            };
+            range_contains(ordinal, start, end, 1, wraparound_ranges)
+        }
+    }
+}
+
+fn period_contains(
+    specifier: &Specifier,
+    ordinal: Ordinal,
+    step: Ordinal,
+    wraparound_ranges: bool,
+) -> bool {
+    if step == 0 {
+        return false;
+    }
+
+    match specifier {
+        Specifier::All => (ordinal - FIRST_YEAR).is_multiple_of(step),
+        Specifier::Point(start) => ordinal >= *start && (ordinal - start).is_multiple_of(step),
+        Specifier::Range(start, end) => {
+            let (Ok(start), Ok(end)) = (ordinal_from_endpoint(start), ordinal_from_endpoint(end))
+            else {
+                return false;
+            };
+            range_contains(ordinal, start, end, step, wraparound_ranges)
+        }
+    }
+}
+
+fn range_contains(
+    ordinal: Ordinal,
+    start: Ordinal,
+    end: Ordinal,
+    step: Ordinal,
+    wraparound_ranges: bool,
+) -> bool {
+    if wraparound_ranges && start == end {
+        return (ordinal - FIRST_YEAR).is_multiple_of(step);
+    }
+    if start <= end {
+        return ordinal >= start && ordinal <= end && (ordinal - start).is_multiple_of(step);
+    }
+    if !wraparound_ranges {
+        return false;
+    }
+
+    ordinal >= start && (ordinal - start).is_multiple_of(step)
+        || wrapped_segment_contains(ordinal, start, end, step)
+}
+
+fn wrapped_segment_contains(ordinal: Ordinal, start: Ordinal, end: Ordinal, step: Ordinal) -> bool {
+    let max = u64::from(LAST_YEAR);
+    let start = u64::from(start);
+    let step = u64::from(step);
+    let last = start + ((max - start) / step) * step;
+    let already_skipped = max - last;
+    let field_len = max - u64::from(FIRST_YEAR) + 1;
+    let to_skip = if last - u64::from(FIRST_YEAR) + step > field_len && already_skipped < step {
+        step - already_skipped
+    } else {
+        0
+    };
+    let ordinal = u64::from(ordinal);
+    let second_start = u64::from(FIRST_YEAR) + to_skip;
+
+    ordinal >= second_start
+        && ordinal <= u64::from(end)
+        && (ordinal - second_start).is_multiple_of(step)
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -2,7 +2,10 @@
 mod tests {
     use chrono::*;
     use chrono_tz::Tz;
-    use cron::{Schedule, TimeUnitSpec};
+    use cron::{
+        CronScheduleParts, DayOfWeekNumbering, DowDomOperand, Schedule, ScheduleConfig,
+        TimeUnitSpec,
+    };
     use std::ops::Bound::{Excluded, Included};
     use std::str::FromStr;
 
@@ -76,6 +79,141 @@ mod tests {
     fn test_not_enough_fields() {
         let expression = "1 2 3 2019";
         assert!(Schedule::from_str(expression).is_err());
+    }
+
+    #[test]
+    fn test_parse_five_part_with_config() {
+        let config = ScheduleConfig {
+            cron_schedule_parts: CronScheduleParts::Five,
+            ..ScheduleConfig::default()
+        };
+        let schedule = Schedule::from_str_with_config("30 9 * * Mon", config).unwrap();
+        let next = schedule
+            .after(&Utc.with_ymd_and_hms(2024, 1, 1, 9, 29, 59).unwrap())
+            .next()
+            .unwrap();
+        assert_eq!(0, next.second());
+    }
+
+    #[test]
+    fn test_default_config_rejects_five_part() {
+        assert!(Schedule::from_str_with_config("30 9 * * Mon", ScheduleConfig::default()).is_err());
+    }
+
+    #[test]
+    fn test_parse_both_part_modes() {
+        let config = ScheduleConfig {
+            cron_schedule_parts: CronScheduleParts::Both,
+            ..ScheduleConfig::default()
+        };
+        assert!(Schedule::from_str_with_config("0 30 9 * * Mon", config).is_ok());
+        assert!(Schedule::from_str_with_config("30 9 * * Mon", config).is_ok());
+    }
+
+    #[test]
+    fn test_parse_vixie_day_of_week_numbering() {
+        let config = ScheduleConfig {
+            day_of_week_numbering: DayOfWeekNumbering::ZeroToSix,
+            ..ScheduleConfig::default()
+        };
+        let schedule = Schedule::from_str_with_config("0 0 0 * * 0", config).unwrap();
+        let sunday = Utc.with_ymd_and_hms(2024, 1, 7, 0, 0, 0).unwrap();
+        let monday = Utc.with_ymd_and_hms(2024, 1, 8, 0, 0, 0).unwrap();
+        assert!(schedule.includes(sunday));
+        assert!(!schedule.includes(monday));
+    }
+
+    #[test]
+    fn test_default_day_of_week_numbering_rejects_zero() {
+        assert!(Schedule::from_str_with_config("0 0 0 * * 0", ScheduleConfig::default()).is_err());
+    }
+
+    #[test]
+    fn test_builder_interface_custom_parts() {
+        let schedule = Schedule::builder()
+            .allowed_cron_schedule_parts(CronScheduleParts::Both)
+            .parse("30 9 * * Mon")
+            .unwrap();
+        let next = schedule
+            .after(&Utc.with_ymd_and_hms(2024, 1, 1, 9, 29, 59).unwrap())
+            .next()
+            .unwrap();
+        assert_eq!(0, next.second());
+    }
+
+    #[test]
+    fn test_builder_interface_default() {
+        let schedule = Schedule::default().parse("0 30 9 * * Mon").unwrap();
+        let next = schedule
+            .after(&Utc.with_ymd_and_hms(2024, 1, 1, 9, 29, 59).unwrap())
+            .next()
+            .unwrap();
+        assert_eq!(30, next.minute());
+    }
+
+    #[test]
+    fn test_builder_interface_vixie() {
+        let schedule = Schedule::vixie().parse("0 0 0 * * 0").unwrap();
+        let sunday = Utc.with_ymd_and_hms(2024, 1, 7, 0, 0, 0).unwrap();
+        assert!(schedule.includes(sunday));
+    }
+
+    #[test]
+    fn test_days_matching_default_and() {
+        let schedule = Schedule::default().parse("0 0 0 1 * Mon").unwrap();
+        let mon_1st = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
+        let mon_8th = Utc.with_ymd_and_hms(2024, 1, 8, 0, 0, 0).unwrap();
+        let thu_1st = Utc.with_ymd_and_hms(2024, 2, 1, 0, 0, 0).unwrap();
+        assert!(schedule.includes(mon_1st));
+        assert!(!schedule.includes(mon_8th));
+        assert!(!schedule.includes(thu_1st));
+    }
+
+    #[test]
+    fn test_days_matching_or() {
+        let schedule = Schedule::builder()
+            .dow_dom_operand(DowDomOperand::Or)
+            .parse("0 0 0 1 * Mon")
+            .unwrap();
+        let mon_1st = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
+        let mon_8th = Utc.with_ymd_and_hms(2024, 1, 8, 0, 0, 0).unwrap();
+        let thu_1st = Utc.with_ymd_and_hms(2024, 2, 1, 0, 0, 0).unwrap();
+        let tue_2nd = Utc.with_ymd_and_hms(2024, 1, 2, 0, 0, 0).unwrap();
+        assert!(schedule.includes(mon_1st));
+        assert!(schedule.includes(mon_8th));
+        assert!(schedule.includes(thu_1st));
+        assert!(!schedule.includes(tue_2nd));
+    }
+
+    #[test]
+    fn test_vixie_includes_or_days_matching() {
+        let schedule = Schedule::vixie().parse("0 0 0 1 * 1").unwrap();
+        let mon_1st = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
+        let mon_8th = Utc.with_ymd_and_hms(2024, 1, 8, 0, 0, 0).unwrap();
+        let thu_1st = Utc.with_ymd_and_hms(2024, 2, 1, 0, 0, 0).unwrap();
+        assert!(schedule.includes(mon_1st));
+        assert!(schedule.includes(mon_8th));
+        assert!(schedule.includes(thu_1st));
+    }
+
+    #[test]
+    fn test_search_interval_limits_next() {
+        let schedule = Schedule::builder()
+            .search_interval(TimeDelta::days(300))
+            .parse("0 0 0 1 1 *")
+            .unwrap();
+        let start = Utc.with_ymd_and_hms(2024, 1, 2, 0, 0, 0).unwrap();
+        assert!(schedule.after(&start).next().is_none());
+    }
+
+    #[test]
+    fn test_search_interval_limits_prev() {
+        let schedule = Schedule::builder()
+            .search_interval(TimeDelta::days(300))
+            .parse("0 0 0 1 1 *")
+            .unwrap();
+        let start = Utc.with_ymd_and_hms(2024, 12, 31, 0, 0, 0).unwrap();
+        assert!(schedule.after(&start).next_back().is_none());
     }
 
     #[test]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -3,8 +3,8 @@ mod tests {
     use chrono::*;
     use chrono_tz::Tz;
     use cron::{
-        CronScheduleParts, DayOfWeekNumbering, DowDomOperand, Schedule, ScheduleConfig,
-        TimeUnitSpec,
+        CronScheduleParts, DayOfWeekNumbering, DowDomOperand, NonexistentTimeBehavior, Schedule,
+        ScheduleConfig, TimeUnitSpec,
     };
     use std::ops::Bound::{Excluded, Included};
     use std::str::FromStr;
@@ -1001,5 +1001,77 @@ mod tests {
                 .collect::<Vec<_>>();
             assert_eq!(actual, expected_reversed, "backward case {}", case.name);
         }
+    }
+
+    #[test]
+    fn test_nonexistent_time_next_existent_forward() {
+        let timezone: Tz = "America/Los_Angeles".parse().unwrap();
+        let schedule = Schedule::builder()
+            .nonexistent_time_behavior(NonexistentTimeBehavior::NextExistent)
+            .parse("0 0 2 * * * *")
+            .unwrap();
+        let start = parse_expected_in_tz(timezone, "2022-03-13T01:59:59-08:00");
+
+        let actual = schedule
+            .after(&start)
+            .take(3)
+            .map(|dt| dt.to_rfc3339())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            actual,
+            vec![
+                "2022-03-13T03:00:00-07:00",
+                "2022-03-14T02:00:00-07:00",
+                "2022-03-15T02:00:00-07:00",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_subhour_nonexistent_time_next_existent_forward() {
+        let timezone: Tz = "America/Los_Angeles".parse().unwrap();
+        let schedule = Schedule::builder()
+            .nonexistent_time_behavior(NonexistentTimeBehavior::NextExistent)
+            .parse("0 30 2 * * * *")
+            .unwrap();
+        let start = parse_expected_in_tz(timezone, "2022-03-13T01:59:59-08:00");
+
+        let actual = schedule
+            .after(&start)
+            .take(2)
+            .map(|dt| dt.to_rfc3339())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            actual,
+            vec!["2022-03-13T03:00:00-07:00", "2022-03-14T02:30:00-07:00",]
+        );
+    }
+
+    #[test]
+    fn test_nonexistent_time_next_existent_backward() {
+        let timezone: Tz = "America/Los_Angeles".parse().unwrap();
+        let schedule = Schedule::builder()
+            .nonexistent_time_behavior(NonexistentTimeBehavior::NextExistent)
+            .parse("0 0 2 * * * *")
+            .unwrap();
+        let start = parse_expected_in_tz(timezone, "2022-03-14T02:00:00-07:00");
+
+        let actual = schedule
+            .after(&start)
+            .rev()
+            .take(3)
+            .map(|dt| dt.to_rfc3339())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            actual,
+            vec![
+                "2022-03-13T03:00:00-07:00",
+                "2022-03-12T02:00:00-08:00",
+                "2022-03-11T02:00:00-08:00",
+            ]
+        );
     }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1029,7 +1029,7 @@ mod tests {
     }
 
     #[test]
-    fn test_subhour_nonexistent_time_next_existent_forward() {
+    fn test_daily_nonexistent_time_next_existent_forward() {
         let timezone: Tz = "America/Los_Angeles".parse().unwrap();
         let schedule = Schedule::builder()
             .nonexistent_time_behavior(NonexistentTimeBehavior::NextExistent)
@@ -1046,6 +1046,48 @@ mod tests {
         assert_eq!(
             actual,
             vec!["2022-03-13T03:00:00-07:00", "2022-03-14T02:30:00-07:00",]
+        );
+    }
+
+    #[test]
+    fn test_hourly_nonexistent_time_skips_to_next_existent_match() {
+        let timezone: Tz = "America/Los_Angeles".parse().unwrap();
+        let schedule = Schedule::builder()
+            .nonexistent_time_behavior(NonexistentTimeBehavior::NextExistent)
+            .parse("0 30 * * * * *")
+            .unwrap();
+        let start = parse_expected_in_tz(timezone, "2022-03-13T01:59:59-08:00");
+
+        let actual = schedule
+            .after(&start)
+            .take(2)
+            .map(|dt| dt.to_rfc3339())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            actual,
+            vec!["2022-03-13T03:30:00-07:00", "2022-03-13T04:30:00-07:00",]
+        );
+    }
+
+    #[test]
+    fn test_subhourly_nonexistent_time_skips_to_next_existent_match() {
+        let timezone: Tz = "America/Los_Angeles".parse().unwrap();
+        let schedule = Schedule::builder()
+            .nonexistent_time_behavior(NonexistentTimeBehavior::NextExistent)
+            .parse("0 */15 2 * * * *")
+            .unwrap();
+        let start = parse_expected_in_tz(timezone, "2022-03-13T01:59:59-08:00");
+
+        let actual = schedule
+            .after(&start)
+            .take(2)
+            .map(|dt| dt.to_rfc3339())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            actual,
+            vec!["2022-03-14T02:00:00-07:00", "2022-03-14T02:15:00-07:00",]
         );
     }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -191,7 +191,18 @@ mod tests {
     }
 
     #[test]
-    fn test_wraparound_ranges_apply_steps_in_circular_order() {
+    fn test_wraparound_ranges_equal_endpoints_are_full_cycle() {
+        let sunday_to_sunday = Schedule::vixie().parse("0 0 0 * * Sun-Sun").unwrap();
+        let monday_to_monday = Schedule::vixie().parse("0 0 0 * * Mon-Mon").unwrap();
+        let january_to_january = Schedule::vixie().parse("0 0 0 * Jan-Jan *").unwrap();
+
+        assert_eq!(7, sunday_to_sunday.days_of_week().count());
+        assert_eq!(7, monday_to_monday.days_of_week().count());
+        assert_eq!(12, january_to_january.months().count());
+    }
+
+    #[test]
+    fn test_wraparound_ranges_apply_croniter_step_boundary_rules() {
         let schedule = Schedule::builder()
             .wraparound_ranges(true)
             .parse("0 0 22-2/2 * Nov-Mar/2 *")
@@ -207,6 +218,39 @@ mod tests {
         assert!(schedule.months().includes(1));
         assert!(!schedule.months().includes(2));
         assert!(schedule.months().includes(3));
+    }
+
+    #[test]
+    fn test_vixie_wraparound_day_of_week_step_skips_boundary_values() {
+        let schedule = Schedule::vixie().parse("0 0 0 * * Thu-Tue/2").unwrap();
+
+        let monday = Utc.with_ymd_and_hms(2024, 1, 8, 0, 0, 0).unwrap();
+        let tuesday = Utc.with_ymd_and_hms(2024, 1, 9, 0, 0, 0).unwrap();
+        let thursday = Utc.with_ymd_and_hms(2024, 1, 11, 0, 0, 0).unwrap();
+        let friday = Utc.with_ymd_and_hms(2024, 1, 12, 0, 0, 0).unwrap();
+        let saturday = Utc.with_ymd_and_hms(2024, 1, 13, 0, 0, 0).unwrap();
+        let sunday = Utc.with_ymd_and_hms(2024, 1, 14, 0, 0, 0).unwrap();
+
+        assert!(schedule.includes(thursday));
+        assert!(schedule.includes(saturday));
+        assert!(schedule.includes(tuesday));
+        assert!(!schedule.includes(friday));
+        assert!(!schedule.includes(sunday));
+        assert!(!schedule.includes(monday));
+    }
+
+    #[test]
+    fn test_wraparound_month_step_skips_boundary_values() {
+        let schedule = Schedule::vixie().parse("0 0 0 * Apr-Mar/2 *").unwrap();
+
+        assert!(schedule.months().includes(4));
+        assert!(schedule.months().includes(6));
+        assert!(schedule.months().includes(8));
+        assert!(schedule.months().includes(10));
+        assert!(schedule.months().includes(12));
+        assert!(schedule.months().includes(3));
+        assert!(!schedule.months().includes(1));
+        assert!(!schedule.months().includes(2));
     }
 
     #[test]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -113,19 +113,137 @@ mod tests {
     #[test]
     fn test_parse_vixie_day_of_week_numbering() {
         let config = ScheduleConfig {
-            day_of_week_numbering: DayOfWeekNumbering::ZeroToSix,
+            day_of_week_numbering: DayOfWeekNumbering::ZeroIndexed,
             ..ScheduleConfig::default()
         };
         let schedule = Schedule::from_str_with_config("0 0 0 * * 0", config).unwrap();
+        let schedule_with_seven = Schedule::from_str_with_config("0 0 0 * * 7", config).unwrap();
         let sunday = Utc.with_ymd_and_hms(2024, 1, 7, 0, 0, 0).unwrap();
         let monday = Utc.with_ymd_and_hms(2024, 1, 8, 0, 0, 0).unwrap();
         assert!(schedule.includes(sunday));
         assert!(!schedule.includes(monday));
+        assert!(schedule_with_seven.includes(sunday));
+        assert!(!schedule_with_seven.includes(monday));
+        assert!(Schedule::from_str_with_config("0 0 0 * * 8", config).is_err());
     }
 
     #[test]
     fn test_default_day_of_week_numbering_rejects_zero() {
         assert!(Schedule::from_str_with_config("0 0 0 * * 0", ScheduleConfig::default()).is_err());
+    }
+
+    #[test]
+    fn test_default_day_of_week_numbering_treats_seven_as_saturday() {
+        let schedule =
+            Schedule::from_str_with_config("0 0 0 * * 7", ScheduleConfig::default()).unwrap();
+        let saturday = Utc.with_ymd_and_hms(2024, 1, 6, 0, 0, 0).unwrap();
+        let sunday = Utc.with_ymd_and_hms(2024, 1, 7, 0, 0, 0).unwrap();
+        assert!(schedule.includes(saturday));
+        assert!(!schedule.includes(sunday));
+    }
+
+    #[test]
+    fn test_wraparound_ranges_disabled_by_default() {
+        assert!(Schedule::builder().parse("0 0 0 * Nov-Mar *").is_err());
+        assert!(Schedule::builder().parse("0 0 22-2 * * *").is_err());
+        assert!(Schedule::builder().parse("0 0 0 * * Fri-Mon").is_err());
+    }
+
+    #[test]
+    fn test_wraparound_ranges_all_fields() {
+        let schedule = Schedule::builder()
+            .wraparound_ranges(true)
+            .parse("55-2 55-2 22-2 28-3 Nov-Mar 6-2 2099-1971")
+            .unwrap();
+
+        assert!(schedule.seconds().includes(55));
+        assert!(schedule.seconds().includes(0));
+        assert!(schedule.seconds().includes(2));
+        assert!(!schedule.seconds().includes(3));
+        assert!(schedule.minutes().includes(55));
+        assert!(schedule.minutes().includes(0));
+        assert!(schedule.minutes().includes(2));
+        assert!(!schedule.minutes().includes(3));
+        assert!(schedule.hours().includes(22));
+        assert!(schedule.hours().includes(0));
+        assert!(schedule.hours().includes(2));
+        assert!(!schedule.hours().includes(3));
+        assert!(schedule.days_of_month().includes(28));
+        assert!(schedule.days_of_month().includes(31));
+        assert!(schedule.days_of_month().includes(1));
+        assert!(schedule.days_of_month().includes(3));
+        assert!(!schedule.days_of_month().includes(4));
+        assert!(schedule.months().includes(11));
+        assert!(schedule.months().includes(12));
+        assert!(schedule.months().includes(1));
+        assert!(schedule.months().includes(3));
+        assert!(!schedule.months().includes(4));
+        assert!(schedule.days_of_week().includes(6));
+        assert!(schedule.days_of_week().includes(7));
+        assert!(schedule.days_of_week().includes(1));
+        assert!(schedule.days_of_week().includes(2));
+        assert!(!schedule.days_of_week().includes(3));
+        assert!(schedule.years().includes(2099));
+        assert!(schedule.years().includes(2100));
+        assert!(schedule.years().includes(1970));
+        assert!(schedule.years().includes(1971));
+        assert!(!schedule.years().includes(1972));
+    }
+
+    #[test]
+    fn test_wraparound_ranges_apply_steps_in_circular_order() {
+        let schedule = Schedule::builder()
+            .wraparound_ranges(true)
+            .parse("0 0 22-2/2 * Nov-Mar/2 *")
+            .unwrap();
+
+        assert!(schedule.hours().includes(22));
+        assert!(!schedule.hours().includes(23));
+        assert!(schedule.hours().includes(0));
+        assert!(!schedule.hours().includes(1));
+        assert!(schedule.hours().includes(2));
+        assert!(schedule.months().includes(11));
+        assert!(!schedule.months().includes(12));
+        assert!(schedule.months().includes(1));
+        assert!(!schedule.months().includes(2));
+        assert!(schedule.months().includes(3));
+    }
+
+    #[test]
+    fn test_vixie_preset_accepts_full_quirks() {
+        let sunday_zero = Schedule::vixie().parse("0 0 0 * * 0").unwrap();
+        let sunday_seven = Schedule::vixie().parse("0 0 0 * * 7").unwrap();
+        let sunday_alias_period = Schedule::vixie().parse("0 0 0 * * 7/2").unwrap();
+        let seven_to_monday = Schedule::vixie().parse("0 0 0 * * 7-mon").unwrap();
+        let friday_to_monday = Schedule::vixie().parse("0 0 0 * * Fri-Mon").unwrap();
+        let november_to_march = Schedule::vixie().parse("0 0 0 * Nov-Mar *").unwrap();
+
+        let friday = Utc.with_ymd_and_hms(2024, 1, 5, 0, 0, 0).unwrap();
+        let saturday = Utc.with_ymd_and_hms(2024, 1, 6, 0, 0, 0).unwrap();
+        let sunday = Utc.with_ymd_and_hms(2024, 1, 7, 0, 0, 0).unwrap();
+        let monday = Utc.with_ymd_and_hms(2024, 1, 8, 0, 0, 0).unwrap();
+        let tuesday = Utc.with_ymd_and_hms(2024, 1, 9, 0, 0, 0).unwrap();
+        let thursday = Utc.with_ymd_and_hms(2024, 1, 11, 0, 0, 0).unwrap();
+
+        assert!(sunday_zero.includes(sunday));
+        assert!(sunday_seven.includes(sunday));
+        assert!(sunday_alias_period.includes(sunday));
+        assert!(!sunday_alias_period.includes(monday));
+        assert!(sunday_alias_period.includes(tuesday));
+        assert!(sunday_alias_period.includes(thursday));
+        assert!(seven_to_monday.includes(sunday));
+        assert!(seven_to_monday.includes(monday));
+        assert!(!seven_to_monday.includes(tuesday));
+        assert!(friday_to_monday.includes(friday));
+        assert!(friday_to_monday.includes(saturday));
+        assert!(friday_to_monday.includes(sunday));
+        assert!(friday_to_monday.includes(monday));
+        assert!(!friday_to_monday.includes(tuesday));
+        assert!(november_to_march.months().includes(11));
+        assert!(november_to_march.months().includes(12));
+        assert!(november_to_march.months().includes(1));
+        assert!(november_to_march.months().includes(3));
+        assert!(!november_to_march.months().includes(4));
     }
 
     #[test]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -101,13 +101,105 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_both_part_modes() {
+    fn test_parse_five_or_six_part_modes() {
         let config = ScheduleConfig {
-            cron_schedule_parts: CronScheduleParts::Both,
+            cron_schedule_parts: CronScheduleParts::FiveOrSix,
             ..ScheduleConfig::default()
         };
         assert!(Schedule::from_str_with_config("0 30 9 * * Mon", config).is_ok());
         assert!(Schedule::from_str_with_config("30 9 * * Mon", config).is_ok());
+        assert!(Schedule::from_str_with_config("0 30 9 * * Mon 2024", config).is_err());
+    }
+
+    #[test]
+    fn test_configured_year_field_modes_iterate_datetimes() {
+        for cron_schedule_parts in [
+            CronScheduleParts::Seven,
+            CronScheduleParts::SixOrSeven,
+            CronScheduleParts::All,
+        ] {
+            let schedule = Schedule::builder()
+                .allowed_cron_schedule_parts(cron_schedule_parts)
+                .parse("0 0 0 1 1 * 2020/2")
+                .unwrap();
+            let start = Utc.with_ymd_and_hms(2019, 12, 31, 23, 59, 59).unwrap();
+            let actual = schedule.after(&start).take(3).collect::<Vec<_>>();
+
+            assert_eq!(
+                actual,
+                vec![
+                    Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap(),
+                    Utc.with_ymd_and_hms(2022, 1, 1, 0, 0, 0).unwrap(),
+                    Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap(),
+                ]
+            );
+        }
+
+        assert!(Schedule::builder()
+            .allowed_cron_schedule_parts(CronScheduleParts::Six)
+            .parse("0 0 0 1 1 * 2020")
+            .is_err());
+    }
+
+    #[test]
+    fn test_configured_year_field_iterates_past_2099() {
+        let schedule = Schedule::builder()
+            .allowed_cron_schedule_parts(CronScheduleParts::Seven)
+            .parse("0 0 0 1 1 * 2100/2")
+            .unwrap();
+        let start = Utc.with_ymd_and_hms(2099, 12, 31, 23, 59, 59).unwrap();
+        let actual = schedule.after(&start).take(3).collect::<Vec<_>>();
+
+        assert_eq!(
+            actual,
+            vec![
+                Utc.with_ymd_and_hms(2100, 1, 1, 0, 0, 0).unwrap(),
+                Utc.with_ymd_and_hms(2102, 1, 1, 0, 0, 0).unwrap(),
+                Utc.with_ymd_and_hms(2104, 1, 1, 0, 0, 0).unwrap(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_configured_year_wraparound_iterates_datetimes() {
+        let schedule = Schedule::builder()
+            .allowed_cron_schedule_parts(CronScheduleParts::Seven)
+            .wraparound_ranges(true)
+            .parse("0 0 0 1 1 * 2098-1971")
+            .unwrap();
+        let start = Utc.with_ymd_and_hms(1969, 12, 31, 23, 59, 59).unwrap();
+        let actual = schedule.after(&start).take(3).collect::<Vec<_>>();
+
+        assert_eq!(
+            actual,
+            vec![
+                Utc.with_ymd_and_hms(1970, 1, 1, 0, 0, 0).unwrap(),
+                Utc.with_ymd_and_hms(1971, 1, 1, 0, 0, 0).unwrap(),
+                Utc.with_ymd_and_hms(2098, 1, 1, 0, 0, 0).unwrap(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_unrestricted_years_continue_past_supported_year_field_max() {
+        let schedule = Schedule::from_str("0 0 0 1 1 *").unwrap();
+        let start = Utc.with_ymd_and_hms(2099, 1, 2, 0, 0, 0).unwrap();
+        let expected = Utc.with_ymd_and_hms(2100, 1, 1, 0, 0, 0).unwrap();
+
+        assert_eq!(Some(expected), schedule.after(&start).next());
+        assert!(schedule.includes(expected));
+        assert!(schedule.years().includes(2100));
+    }
+
+    #[test]
+    fn test_unrestricted_years_are_bounded_by_search_interval() {
+        let schedule = Schedule::builder()
+            .search_interval(TimeDelta::days(300))
+            .parse("0 0 0 1 1 *")
+            .unwrap();
+        let start = Utc.with_ymd_and_hms(2099, 1, 2, 0, 0, 0).unwrap();
+
+        assert_eq!(None, schedule.after(&start).next());
     }
 
     #[test]
@@ -293,7 +385,7 @@ mod tests {
     #[test]
     fn test_builder_interface_custom_parts() {
         let schedule = Schedule::builder()
-            .allowed_cron_schedule_parts(CronScheduleParts::Both)
+            .allowed_cron_schedule_parts(CronScheduleParts::FiveOrSix)
             .parse("30 9 * * Mon")
             .unwrap();
         let next = schedule


### PR DESCRIPTION
## Summary
Adds configurable seven-field cron parsing with an explicit year field (`1970..=2099`) while keeping default parsing non-breaking. Omitted or `*` years remain unrestricted and are bounded by `search_interval` during iteration.

Stacked on #150.

## Tests
- year-field parsing modes and datetime iteration
- year wraparound and unrestricted-year search bounds
- `cargo test --all-features`