### PR TITLE
Optimize ordinal iteration with compact sets

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,6 +22,8 @@ jobs:
       run: cargo test --verbose
     - name: Run tests (all features)
       run: cargo test --verbose --all-features
+    - name: Compile benchmarks
+      run: cargo bench --no-run
     - name: Build docs
       run: cargo doc --no-deps --verbose
     - name: Check formatting

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,12 @@ name = "cron"
 [dependencies]
 chrono = { version = "~0.4", default-features = false, features = ["clock"] }
 winnow = "0.7.0"
-once_cell = "1.10"
 phf = { version = "0.11", features = ["macros"] }
 serde = {version = "1.0.164", optional = true }
 
 [dev-dependencies]
 chrono-tz = "~0.6"
+criterion = "0.8"
 serde_test = "1.0.164"
 
 # Dev-dependency for feature "serde".
@@ -31,3 +31,7 @@ postcard = { version = "1.0.10", default-features = false, features = ["use-std"
 
 [features]
 serde = ["dep:serde"]
+
+[[bench]]
+name = "schedule"
+harness = false

--- a/benches/schedule.rs
+++ b/benches/schedule.rs
@@ -1,0 +1,238 @@
+use chrono::{DateTime, TimeZone, Utc};
+use chrono_tz::Tz;
+use criterion::{criterion_group, criterion_main, Criterion};
+use cron::Schedule;
+use std::hint::black_box;
+use std::str::FromStr;
+
+const PARSE_CASES: &[(&str, &str)] = &[
+    ("all_fields_dense", "* * * * * * *"),
+    (
+        "named_ranges_and_steps",
+        "0 30 9,12,15 1,15 May-Aug Mon,Wed,Fri 2018/2",
+    ),
+    ("shorthand_hourly", "@hourly"),
+    ("sparse_year_bound", "0 0 0 29 2 * 2096"),
+];
+
+fn schedule(expression: &str) -> Schedule {
+    Schedule::from_str(expression).unwrap()
+}
+
+fn tz(name: &str) -> Tz {
+    name.parse().unwrap()
+}
+
+fn utc_datetime(
+    year: i32,
+    month: u32,
+    day: u32,
+    hour: u32,
+    minute: u32,
+    second: u32,
+) -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(year, month, day, hour, minute, second)
+        .unwrap()
+}
+
+fn tz_datetime(
+    timezone: Tz,
+    year: i32,
+    month: u32,
+    day: u32,
+    hour: u32,
+    minute: u32,
+    second: u32,
+) -> DateTime<Tz> {
+    timezone
+        .with_ymd_and_hms(year, month, day, hour, minute, second)
+        .unwrap()
+}
+
+fn consume_forward<Z>(schedule: &Schedule, start: &DateTime<Z>, count: usize) -> i64
+where
+    Z: TimeZone,
+{
+    schedule
+        .after(start)
+        .take(count)
+        .fold(0, |acc, date_time| acc ^ date_time.timestamp())
+}
+
+fn consume_reverse<Z>(schedule: &Schedule, start: &DateTime<Z>, count: usize) -> i64
+where
+    Z: TimeZone,
+{
+    schedule
+        .after(start)
+        .rev()
+        .take(count)
+        .fold(0, |acc, date_time| acc ^ date_time.timestamp())
+}
+
+fn bench_parse(c: &mut Criterion) {
+    let mut group = c.benchmark_group("parse");
+    for &(name, expression) in PARSE_CASES {
+        group.bench_function(name, |b| {
+            b.iter(|| Schedule::from_str(black_box(expression)).unwrap())
+        });
+    }
+    group.finish();
+}
+
+fn bench_includes(c: &mut Criterion) {
+    let schedule = schedule("0,15,30,45 0/5 8-17 ? Jan,Jun,Dec Mon-Fri 2020-2030");
+    let london = tz("Europe/London");
+    let date_times = [
+        tz_datetime(london, 2025, 1, 6, 8, 0, 0),
+        tz_datetime(london, 2025, 1, 6, 8, 5, 15),
+        tz_datetime(london, 2025, 6, 11, 17, 55, 45),
+        tz_datetime(london, 2025, 12, 26, 11, 30, 30),
+        tz_datetime(london, 2025, 2, 6, 8, 0, 0),
+        tz_datetime(london, 2025, 1, 4, 8, 0, 0),
+        tz_datetime(london, 2025, 1, 6, 7, 55, 0),
+        tz_datetime(london, 2031, 1, 6, 8, 0, 0),
+    ];
+
+    let mut group = c.benchmark_group("includes");
+    group.bench_function("single_hit", |b| {
+        let date_time = date_times[0];
+        b.iter(|| schedule.includes(black_box(date_time)))
+    });
+    group.bench_function("mixed_hits_and_misses", |b| {
+        b.iter(|| {
+            let matches = date_times.iter().fold(0_u64, |matches, date_time| {
+                matches + u64::from(schedule.includes(black_box(*date_time)))
+            });
+            black_box(matches)
+        })
+    });
+    group.finish();
+}
+
+fn bench_dense_iteration(c: &mut Criterion) {
+    let every_second = schedule("* * * * * * *");
+    let every_minute = schedule("0 * * * * * *");
+    let start = utc_datetime(2025, 1, 1, 0, 0, 0);
+    let mut group = c.benchmark_group("dense_iteration");
+
+    group.bench_function("every_second_forward_1024", |b| {
+        b.iter(|| consume_forward(black_box(&every_second), black_box(&start), black_box(1024)))
+    });
+    group.bench_function("every_second_reverse_1024", |b| {
+        b.iter(|| consume_reverse(black_box(&every_second), black_box(&start), black_box(1024)))
+    });
+    group.bench_function("every_minute_forward_1024", |b| {
+        b.iter(|| consume_forward(black_box(&every_minute), black_box(&start), black_box(1024)))
+    });
+
+    group.finish();
+}
+
+fn bench_sparse_iteration(c: &mut Criterion) {
+    let leap_day = schedule("0 0 0 29 2 * *");
+    let distant_year = schedule("0 0 0 1 1 * 2100");
+    let impossible_february_day = schedule("0 0 0 31 2 * *");
+    let start = utc_datetime(1970, 1, 1, 0, 0, 0);
+    let reverse_start = utc_datetime(2101, 1, 1, 0, 0, 0);
+    let mut group = c.benchmark_group("sparse_year_bound_iteration");
+
+    group.bench_function("leap_day_forward_16", |b| {
+        b.iter(|| consume_forward(black_box(&leap_day), black_box(&start), black_box(16)))
+    });
+    group.bench_function("leap_day_reverse_16", |b| {
+        b.iter(|| {
+            consume_reverse(
+                black_box(&leap_day),
+                black_box(&reverse_start),
+                black_box(16),
+            )
+        })
+    });
+    group.bench_function("distant_year_next_from_1970", |b| {
+        b.iter(|| {
+            let next = distant_year.after(black_box(&start)).next();
+            black_box(next)
+        })
+    });
+    group.bench_function("impossible_date_exhausts_years", |b| {
+        b.iter(|| {
+            let next = impossible_february_day.after(black_box(&start)).next();
+            black_box(next)
+        })
+    });
+
+    group.finish();
+}
+
+fn bench_dst_iteration(c: &mut Criterion) {
+    let los_angeles = tz("America/Los_Angeles");
+    let berlin = tz("Europe/Berlin");
+    let hourly = schedule("0 0 * * * * *");
+    let every_15_minutes = schedule("0 0/15 * * * * *");
+    let nonexistent_daily_time = schedule("0 30 2 * * * *");
+    let los_angeles_fall_back_start = tz_datetime(los_angeles, 2022, 11, 6, 0, 30, 0);
+    let los_angeles_fall_back_reverse_start = tz_datetime(los_angeles, 2022, 11, 6, 4, 30, 0);
+    let los_angeles_spring_forward_start = tz_datetime(los_angeles, 2022, 3, 13, 0, 30, 0);
+    let berlin_fall_back_start = tz_datetime(berlin, 2022, 10, 30, 1, 30, 0);
+    let nonexistent_start = tz_datetime(los_angeles, 2022, 3, 12, 0, 0, 0);
+    let mut group = c.benchmark_group("dst_nonexistent_time_iteration");
+
+    group.bench_function("spring_forward_hourly_forward_8", |b| {
+        b.iter(|| {
+            consume_forward(
+                black_box(&hourly),
+                black_box(&los_angeles_spring_forward_start),
+                black_box(8),
+            )
+        })
+    });
+    group.bench_function("fall_back_subhourly_forward_12", |b| {
+        b.iter(|| {
+            consume_forward(
+                black_box(&every_15_minutes),
+                black_box(&los_angeles_fall_back_start),
+                black_box(12),
+            )
+        })
+    });
+    group.bench_function("fall_back_subhourly_reverse_12", |b| {
+        b.iter(|| {
+            consume_reverse(
+                black_box(&every_15_minutes),
+                black_box(&los_angeles_fall_back_reverse_start),
+                black_box(12),
+            )
+        })
+    });
+    group.bench_function("berlin_fall_back_full_repeated_hour", |b| {
+        b.iter(|| {
+            consume_forward(
+                black_box(&every_15_minutes),
+                black_box(&berlin_fall_back_start),
+                black_box(12),
+            )
+        })
+    });
+    group.bench_function("nonexistent_0230_daily_skips_gap", |b| {
+        b.iter(|| {
+            consume_forward(
+                black_box(&nonexistent_daily_time),
+                black_box(&nonexistent_start),
+                black_box(4),
+            )
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_parse,
+    bench_includes,
+    bench_dense_iteration,
+    bench_sparse_iteration,
+    bench_dst_iteration
+);
+criterion_main!(benches);

--- a/src/ordinal.rs
+++ b/src/ordinal.rs
@@ -1,8 +1,617 @@
-use std::collections::BTreeSet;
+use std::ops::{Bound, RangeBounds};
 
 pub type Ordinal = u32;
-// TODO: Make OrdinalSet an enum.
-// It should either be a BTreeSet of ordinals or an `All` option to save space.
-// `All` can iterate from inclusive_min to inclusive_max and answer membership
-// queries
-pub type OrdinalSet = BTreeSet<Ordinal>;
+
+const WORDS: usize = 4;
+const BITS_PER_WORD: u32 = u64::BITS;
+const MAX_ORDINAL_COUNT: u32 = WORDS as u32 * BITS_PER_WORD;
+
+#[derive(Clone, Debug, Eq)]
+pub enum OrdinalSet {
+    All {
+        min: Ordinal,
+        max: Ordinal,
+    },
+    Explicit {
+        min: Ordinal,
+        max: Ordinal,
+        bits: [u64; WORDS],
+        count: u32,
+    },
+}
+
+impl OrdinalSet {
+    pub fn empty(min: Ordinal, max: Ordinal) -> Self {
+        Self::assert_valid_domain(min, max);
+        Self::Explicit {
+            min,
+            max,
+            bits: [0; WORDS],
+            count: 0,
+        }
+    }
+
+    pub fn all(min: Ordinal, max: Ordinal) -> Self {
+        Self::assert_valid_domain(min, max);
+        Self::All { min, max }
+    }
+
+    #[allow(clippy::should_implement_trait)]
+    pub fn from_iter<I>(min: Ordinal, max: Ordinal, ordinals: I) -> Self
+    where
+        I: IntoIterator<Item = Ordinal>,
+    {
+        let mut set = Self::empty(min, max);
+        for ordinal in ordinals {
+            set.insert(ordinal);
+        }
+        set
+    }
+
+    pub fn insert(&mut self, ordinal: Ordinal) -> bool {
+        let (min, max) = self.domain();
+        assert!(
+            Self::ordinal_is_in_domain(min, max, ordinal),
+            "ordinal {ordinal} outside supported domain {min}-{max}"
+        );
+
+        match self {
+            Self::All { .. } => false,
+            Self::Explicit {
+                bits,
+                count,
+                min,
+                max,
+            } => {
+                let (word, mask) = Self::word_and_mask(*min, ordinal);
+                if bits[word] & mask != 0 {
+                    return false;
+                }
+
+                bits[word] |= mask;
+                *count += 1;
+                if *count == Self::domain_len(*min, *max) {
+                    *self = Self::All {
+                        min: *min,
+                        max: *max,
+                    };
+                }
+                true
+            }
+        }
+    }
+
+    pub fn union_assign(&mut self, other: &Self) {
+        let (min, max) = self.domain();
+        assert_eq!(
+            (min, max),
+            other.domain(),
+            "cannot union ordinal sets with different domains"
+        );
+
+        match (&mut *self, other) {
+            (Self::All { .. }, _) => {}
+            (_, Self::All { .. }) => *self = Self::All { min, max },
+            (
+                Self::Explicit { bits, count, .. },
+                Self::Explicit {
+                    bits: other_bits, ..
+                },
+            ) => {
+                for (word, other_word) in bits.iter_mut().zip(other_bits.iter()) {
+                    *word |= *other_word;
+                }
+                *count = bits.iter().map(|word| word.count_ones()).sum();
+                self.normalize();
+            }
+        }
+    }
+
+    pub fn contains(&self, ordinal: Ordinal) -> bool {
+        let (min, max) = self.domain();
+        if !Self::ordinal_is_in_domain(min, max, ordinal) {
+            return false;
+        }
+
+        match self {
+            Self::All { .. } => true,
+            Self::Explicit { bits, min, .. } => {
+                let (word, mask) = Self::word_and_mask(*min, ordinal);
+                bits[word] & mask != 0
+            }
+        }
+    }
+
+    pub fn count(&self) -> u32 {
+        match self {
+            Self::All { min, max } => Self::domain_len(*min, *max),
+            Self::Explicit { count, .. } => *count,
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.count() as usize
+    }
+
+    pub fn is_all(&self) -> bool {
+        matches!(self, Self::All { .. })
+    }
+
+    pub fn iter(&self) -> OrdinalSetIter<'_> {
+        self.range(..)
+    }
+
+    pub fn range<R>(&self, range: R) -> OrdinalSetIter<'_>
+    where
+        R: RangeBounds<Ordinal>,
+    {
+        let Some((front, back)) = self.range_bounds(range) else {
+            return OrdinalSetIter::empty();
+        };
+
+        match self {
+            Self::All { .. } => OrdinalSetIter::all(front, back),
+            Self::Explicit { min, max, bits, .. } => {
+                OrdinalSetIter::explicit(*min, *max, bits, front, back)
+            }
+        }
+    }
+
+    pub fn next_ge(&self, ordinal: Ordinal) -> Option<Ordinal> {
+        let (min, max) = self.domain();
+        match self {
+            Self::All { .. } => {
+                if ordinal <= min {
+                    Some(min)
+                } else if ordinal <= max {
+                    Some(ordinal)
+                } else {
+                    None
+                }
+            }
+            Self::Explicit { bits, .. } => Self::next_ge_in_bits(min, max, bits, ordinal),
+        }
+    }
+
+    pub fn prev_le(&self, ordinal: Ordinal) -> Option<Ordinal> {
+        let (min, max) = self.domain();
+        match self {
+            Self::All { .. } => {
+                if ordinal < min {
+                    None
+                } else if ordinal >= max {
+                    Some(max)
+                } else {
+                    Some(ordinal)
+                }
+            }
+            Self::Explicit { bits, .. } => Self::prev_le_in_bits(min, max, bits, ordinal),
+        }
+    }
+
+    fn normalize(&mut self) {
+        let convert_to_all = match self {
+            Self::All { .. } => false,
+            Self::Explicit {
+                min, max, count, ..
+            } => *count == Self::domain_len(*min, *max),
+        };
+
+        if convert_to_all {
+            let (min, max) = self.domain();
+            *self = Self::All { min, max };
+        }
+    }
+
+    fn domain(&self) -> (Ordinal, Ordinal) {
+        match self {
+            Self::All { min, max } | Self::Explicit { min, max, .. } => (*min, *max),
+        }
+    }
+
+    fn range_bounds<R>(&self, range: R) -> Option<(Ordinal, Ordinal)>
+    where
+        R: RangeBounds<Ordinal>,
+    {
+        let (min, max) = self.domain();
+        let front = match range.start_bound() {
+            Bound::Included(&ordinal) => {
+                if ordinal > max {
+                    return None;
+                }
+                ordinal.max(min)
+            }
+            Bound::Excluded(&ordinal) => {
+                if ordinal >= max {
+                    return None;
+                }
+                ordinal.saturating_add(1).max(min)
+            }
+            Bound::Unbounded => min,
+        };
+
+        let back = match range.end_bound() {
+            Bound::Included(&ordinal) => {
+                if ordinal < min {
+                    return None;
+                }
+                ordinal.min(max)
+            }
+            Bound::Excluded(&ordinal) => {
+                if ordinal <= min {
+                    return None;
+                }
+                ordinal.saturating_sub(1).min(max)
+            }
+            Bound::Unbounded => max,
+        };
+
+        (front <= back).then_some((front, back))
+    }
+
+    fn next_ge_in_bits(
+        min: Ordinal,
+        max: Ordinal,
+        bits: &[u64; WORDS],
+        ordinal: Ordinal,
+    ) -> Option<Ordinal> {
+        if ordinal > max {
+            return None;
+        }
+
+        let start = ordinal.max(min);
+        let offset = start - min;
+        let mut word_index = (offset / BITS_PER_WORD) as usize;
+        let bit_index = offset % BITS_PER_WORD;
+        let mut word = bits[word_index] & (!0u64 << bit_index);
+
+        loop {
+            if word != 0 {
+                let ordinal = min + word_index as u32 * BITS_PER_WORD + word.trailing_zeros();
+                return (ordinal <= max).then_some(ordinal);
+            }
+
+            word_index += 1;
+            if word_index == WORDS {
+                return None;
+            }
+            word = bits[word_index];
+        }
+    }
+
+    fn prev_le_in_bits(
+        min: Ordinal,
+        max: Ordinal,
+        bits: &[u64; WORDS],
+        ordinal: Ordinal,
+    ) -> Option<Ordinal> {
+        if ordinal < min {
+            return None;
+        }
+
+        let start = ordinal.min(max);
+        let offset = start - min;
+        let mut word_index = (offset / BITS_PER_WORD) as usize;
+        let bit_index = offset % BITS_PER_WORD;
+        let mask = if bit_index == BITS_PER_WORD - 1 {
+            !0u64
+        } else {
+            (1u64 << (bit_index + 1)) - 1
+        };
+        let mut word = bits[word_index] & mask;
+
+        loop {
+            if word != 0 {
+                let ordinal = min
+                    + word_index as u32 * BITS_PER_WORD
+                    + (BITS_PER_WORD - 1 - word.leading_zeros());
+                return (ordinal <= max).then_some(ordinal);
+            }
+
+            if word_index == 0 {
+                return None;
+            }
+            word_index -= 1;
+            word = bits[word_index];
+        }
+    }
+
+    fn word_and_mask(min: Ordinal, ordinal: Ordinal) -> (usize, u64) {
+        let offset = ordinal - min;
+        let word = (offset / BITS_PER_WORD) as usize;
+        let bit = offset % BITS_PER_WORD;
+        (word, 1u64 << bit)
+    }
+
+    fn assert_valid_domain(min: Ordinal, max: Ordinal) {
+        assert!(
+            min <= max,
+            "ordinal domain minimum {min} must be less than or equal to maximum {max}"
+        );
+        assert!(
+            Self::domain_len(min, max) <= MAX_ORDINAL_COUNT,
+            "ordinal domain {min}-{max} is too large for the fixed bitset"
+        );
+    }
+
+    fn domain_len(min: Ordinal, max: Ordinal) -> u32 {
+        max - min + 1
+    }
+
+    fn ordinal_is_in_domain(min: Ordinal, max: Ordinal, ordinal: Ordinal) -> bool {
+        (min..=max).contains(&ordinal)
+    }
+}
+
+impl PartialEq for OrdinalSet {
+    fn eq(&self, other: &Self) -> bool {
+        if self.domain() != other.domain() {
+            return false;
+        }
+
+        match (self, other) {
+            (Self::All { .. }, Self::All { .. }) => true,
+            (
+                Self::Explicit { bits, count, .. },
+                Self::Explicit {
+                    bits: other_bits,
+                    count: other_count,
+                    ..
+                },
+            ) => count == other_count && bits == other_bits,
+            _ => self.is_all() && other.is_all(),
+        }
+    }
+}
+
+impl<'a> IntoIterator for &'a OrdinalSet {
+    type Item = Ordinal;
+    type IntoIter = OrdinalSetIter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+pub struct OrdinalSetIter<'a> {
+    state: OrdinalSetIterState<'a>,
+}
+
+enum OrdinalSetIterState<'a> {
+    Empty,
+    All {
+        front: Ordinal,
+        back: Ordinal,
+    },
+    Explicit {
+        min: Ordinal,
+        max: Ordinal,
+        bits: &'a [u64; WORDS],
+        front: Ordinal,
+        back: Ordinal,
+    },
+}
+
+impl OrdinalSetIter<'_> {
+    fn empty() -> Self {
+        Self {
+            state: OrdinalSetIterState::Empty,
+        }
+    }
+
+    fn all(front: Ordinal, back: Ordinal) -> Self {
+        Self {
+            state: OrdinalSetIterState::All { front, back },
+        }
+    }
+
+    fn explicit<'a>(
+        min: Ordinal,
+        max: Ordinal,
+        bits: &'a [u64; WORDS],
+        front: Ordinal,
+        back: Ordinal,
+    ) -> OrdinalSetIter<'a> {
+        OrdinalSetIter {
+            state: OrdinalSetIterState::Explicit {
+                min,
+                max,
+                bits,
+                front,
+                back,
+            },
+        }
+    }
+}
+
+impl Iterator for OrdinalSetIter<'_> {
+    type Item = Ordinal;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match &mut self.state {
+            OrdinalSetIterState::Empty => None,
+            OrdinalSetIterState::All { front, back } => {
+                if front > back {
+                    self.state = OrdinalSetIterState::Empty;
+                    return None;
+                }
+
+                let ordinal = *front;
+                if ordinal == *back {
+                    self.state = OrdinalSetIterState::Empty;
+                } else {
+                    *front += 1;
+                }
+                Some(ordinal)
+            }
+            OrdinalSetIterState::Explicit {
+                min,
+                max,
+                bits,
+                front,
+                back,
+            } => {
+                let ordinal = OrdinalSet::next_ge_in_bits(*min, *max, bits, *front)?;
+                if ordinal > *back {
+                    self.state = OrdinalSetIterState::Empty;
+                    return None;
+                }
+
+                if ordinal == *back {
+                    self.state = OrdinalSetIterState::Empty;
+                } else {
+                    *front = ordinal + 1;
+                }
+                Some(ordinal)
+            }
+        }
+    }
+}
+
+impl DoubleEndedIterator for OrdinalSetIter<'_> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        match &mut self.state {
+            OrdinalSetIterState::Empty => None,
+            OrdinalSetIterState::All { front, back } => {
+                if front > back {
+                    self.state = OrdinalSetIterState::Empty;
+                    return None;
+                }
+
+                let ordinal = *back;
+                if ordinal == *front {
+                    self.state = OrdinalSetIterState::Empty;
+                } else {
+                    *back -= 1;
+                }
+                Some(ordinal)
+            }
+            OrdinalSetIterState::Explicit {
+                min,
+                max,
+                bits,
+                front,
+                back,
+            } => {
+                let ordinal = OrdinalSet::prev_le_in_bits(*min, *max, bits, *back)?;
+                if ordinal < *front {
+                    self.state = OrdinalSetIterState::Empty;
+                    return None;
+                }
+
+                if ordinal == *front {
+                    self.state = OrdinalSetIterState::Empty;
+                } else {
+                    *back = ordinal - 1;
+                }
+                Some(ordinal)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ops::Bound::{Excluded, Included, Unbounded};
+
+    #[test]
+    fn all_membership_count_and_iteration() {
+        let set = OrdinalSet::all(3, 7);
+
+        assert!(set.contains(3));
+        assert!(set.contains(5));
+        assert!(set.contains(7));
+        assert!(!set.contains(2));
+        assert!(!set.contains(8));
+        assert_eq!(set.count(), 5);
+        assert!(set.is_all());
+        assert_eq!(set.iter().collect::<Vec<_>>(), vec![3, 4, 5, 6, 7]);
+        assert_eq!(set.iter().rev().collect::<Vec<_>>(), vec![7, 6, 5, 4, 3]);
+        assert_eq!(
+            set.range((Included(4), Excluded(7))).collect::<Vec<_>>(),
+            vec![4, 5, 6]
+        );
+    }
+
+    #[test]
+    fn explicit_insert_duplicate_and_canonicalize_to_all() {
+        let mut set = OrdinalSet::empty(0, 2);
+
+        assert!(set.insert(0));
+        assert!(!set.insert(0));
+        assert_eq!(set.count(), 1);
+        assert!(!set.is_all());
+        assert!(set.insert(2));
+        assert!(set.insert(1));
+
+        assert!(set.is_all());
+        assert_eq!(set.count(), 3);
+        assert_eq!(set.iter().collect::<Vec<_>>(), vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn union_assign_canonicalizes_full_domain() {
+        let mut first = OrdinalSet::from_iter(1, 4, [1, 3]);
+        let second = OrdinalSet::from_iter(1, 4, [2, 4]);
+
+        first.union_assign(&second);
+
+        assert!(first.is_all());
+        assert_eq!(first.iter().collect::<Vec<_>>(), vec![1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn explicit_range_bounds_and_empty_ranges() {
+        let set = OrdinalSet::from_iter(10, 20, [10, 12, 15, 20]);
+
+        assert_eq!(
+            set.range((Included(10), Included(15))).collect::<Vec<_>>(),
+            vec![10, 12, 15]
+        );
+        assert_eq!(
+            set.range((Excluded(10), Excluded(20))).collect::<Vec<_>>(),
+            vec![12, 15]
+        );
+        assert_eq!(
+            set.range((Unbounded, Included(12))).collect::<Vec<_>>(),
+            vec![10, 12]
+        );
+        assert_eq!(
+            set.range((Excluded(15), Unbounded)).collect::<Vec<_>>(),
+            vec![20]
+        );
+        assert_eq!(
+            set.range((Included(0), Included(99))).collect::<Vec<_>>(),
+            vec![10, 12, 15, 20]
+        );
+        assert!(set.range((Included(21), Unbounded)).next().is_none());
+        assert!(set.range((Unbounded, Excluded(10))).next().is_none());
+        assert!(set.range((Included(15), Excluded(15))).next().is_none());
+        assert_eq!(
+            set.range((Included(12), Included(20)))
+                .rev()
+                .collect::<Vec<_>>(),
+            vec![20, 15, 12]
+        );
+    }
+
+    #[test]
+    fn next_ge_and_prev_le_cover_edges_and_gaps() {
+        let set = OrdinalSet::from_iter(5, 15, [5, 8, 12, 15]);
+
+        assert_eq!(set.next_ge(0), Some(5));
+        assert_eq!(set.next_ge(5), Some(5));
+        assert_eq!(set.next_ge(6), Some(8));
+        assert_eq!(set.next_ge(13), Some(15));
+        assert_eq!(set.next_ge(15), Some(15));
+        assert_eq!(set.next_ge(16), None);
+
+        assert_eq!(set.prev_le(20), Some(15));
+        assert_eq!(set.prev_le(15), Some(15));
+        assert_eq!(set.prev_le(14), Some(12));
+        assert_eq!(set.prev_le(6), Some(5));
+        assert_eq!(set.prev_le(5), Some(5));
+        assert_eq!(set.prev_le(4), None);
+    }
+}

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -70,12 +70,10 @@ where
         {
             return Ok(T::all());
         }
-        let mut ordinals = OrdinalSet::new();
+        let mut ordinals = T::empty_ordinals();
         for specifier in field.specifiers {
             let specifier_ordinals: OrdinalSet = T::ordinals_from_root_specifier(&specifier)?;
-            for ordinal in specifier_ordinals {
-                ordinals.insert(T::validate_ordinal(ordinal)?);
-            }
+            ordinals.union_assign(&specifier_ordinals);
         }
         Ok(T::from_ordinal_set(ordinals))
     }

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -38,6 +38,9 @@ impl Schedule {
         Z: TimeZone,
     {
         let mut query = NextAfterQuery::from(after);
+        let fields = &self.fields;
+        let timezone = after.timezone();
+        let days_of_week_is_all = fields.days_of_week.is_all();
         // Ambiguous naive datetimes translate to two local datetimes. This
         // iteration uses naive datetimes and could skip the second local
         // datetime, where the second may match the pattern. This deferred
@@ -51,37 +54,29 @@ impl Schedule {
         // does not get stuck repeating matches from the first fold or skip
         // matches in the second fold.
         let after_naive = after.naive_local();
-        let after_in_first_fold = match after.timezone().from_local_datetime(&after_naive) {
+        let after_in_first_fold = match timezone.from_local_datetime(&after_naive) {
             LocalResult::Ambiguous(first, second) => {
                 let earlier = min(first, second);
                 *after == earlier
             }
             _ => false,
         };
-        for year in self
-            .fields
+        for year in fields
             .years
-            .ordinals()
             .range((Included(query.year_lower_bound()), Unbounded))
-            .cloned()
         {
             // It's a future year, the current year's range is irrelevant.
             if year > after.year() as u32 {
                 query.reset_month();
             }
             let month_start = query.month_lower_bound();
-            if !self.fields.months.ordinals().contains(&month_start) {
+            if !fields.months.includes(month_start) {
                 query.reset_month();
             }
             let month_range = (Included(month_start), Included(Months::inclusive_max()));
-            for month in self.fields.months.ordinals().range(month_range).cloned() {
+            for month in fields.months.range(month_range) {
                 let day_of_month_start = query.day_of_month_lower_bound();
-                if !self
-                    .fields
-                    .days_of_month
-                    .ordinals()
-                    .contains(&day_of_month_start)
-                {
+                if !fields.days_of_month.includes(day_of_month_start) {
                     query.reset_day_of_month();
                 }
                 let day_of_month_end = days_in_month(month, year);
@@ -90,20 +85,16 @@ impl Schedule {
                     Included(day_of_month_end),
                 );
 
-                let mut day_iter = self
-                    .fields
+                let mut day_iter = fields
                     .days_of_month
-                    .ordinals()
                     .range(day_of_month_range)
-                    .cloned()
                     .filter(|&day| {
-                        self.fields.days_of_week.is_all()
+                        days_of_week_is_all
                             || NaiveDate::from_ymd_opt(year as i32, month, day)
                                 .map(|d| {
-                                    self.fields
+                                    fields
                                         .days_of_week
-                                        .ordinals()
-                                        .contains(&d.weekday().number_from_sunday())
+                                        .includes(d.weekday().number_from_sunday())
                                 })
                                 .unwrap_or(false)
                     })
@@ -113,12 +104,12 @@ impl Schedule {
                 }
                 for day_of_month in day_iter {
                     let hour_start = query.hour_lower_bound();
-                    if !self.fields.hours.ordinals().contains(&hour_start) {
+                    if !fields.hours.includes(hour_start) {
                         query.reset_hour();
                     }
                     let hour_range = (Included(hour_start), Included(Hours::inclusive_max()));
 
-                    for hour in self.fields.hours.ordinals().range(hour_range).cloned() {
+                    for hour in fields.hours.range(hour_range) {
                         // The first fold is the first repeat of the DST offset,
                         // typically one hour. Because this iteration is done in
                         // naive time, it can skip matches after finding one in
@@ -135,29 +126,26 @@ impl Schedule {
                         } else {
                             query_minute_start
                         };
-                        if !self.fields.minutes.ordinals().contains(&minute_start) {
+                        if !fields.minutes.includes(minute_start) {
                             query.reset_minute();
                         }
                         let minute_range =
                             (Included(minute_start), Included(Minutes::inclusive_max()));
 
-                        for minute in self.fields.minutes.ordinals().range(minute_range).cloned() {
+                        for minute in fields.minutes.range(minute_range) {
                             let query_second_start = query.second_lower_bound();
                             let second_start = if fold_hour_scan {
                                 Seconds::inclusive_min()
                             } else {
                                 query_second_start
                             };
-                            if !self.fields.seconds.ordinals().contains(&second_start) {
+                            if !fields.seconds.includes(second_start) {
                                 query.reset_second();
                             }
                             let second_range =
                                 (Included(second_start), Included(Seconds::inclusive_max()));
 
-                            for second in
-                                self.fields.seconds.ordinals().range(second_range).cloned()
-                            {
-                                let timezone = after.timezone();
+                            for second in fields.seconds.range(second_range) {
                                 let local_result = timezone.with_ymd_and_hms(
                                     year as i32,
                                     month,
@@ -215,6 +203,9 @@ impl Schedule {
         Z: TimeZone,
     {
         let mut query = PrevFromQuery::from(before);
+        let fields = &self.fields;
+        let timezone = before.timezone();
+        let days_of_week_is_all = fields.days_of_week.is_all();
         // See `next_after` for folded-time details. This is the reverse scan's
         // deferred candidate for an earlier local datetime that may still be
         // the previous chronological match.
@@ -222,43 +213,28 @@ impl Schedule {
         // See `next_after` for folded-time details. This flag handles starting
         // from the second fold while scanning backward.
         let before_naive = before.naive_local();
-        let before_in_second_fold = match before.timezone().from_local_datetime(&before_naive) {
+        let before_in_second_fold = match timezone.from_local_datetime(&before_naive) {
             LocalResult::Ambiguous(first, second) => {
                 let later = max(first, second);
                 *before == later
             }
             _ => false,
         };
-        for year in self
-            .fields
+        for year in fields
             .years
-            .ordinals()
             .range((Unbounded, Included(query.year_upper_bound())))
             .rev()
-            .cloned()
         {
             let month_start = query.month_upper_bound();
 
-            if !self.fields.months.ordinals().contains(&month_start) {
+            if !fields.months.includes(month_start) {
                 query.reset_month();
             }
             let month_range = (Included(Months::inclusive_min()), Included(month_start));
 
-            for month in self
-                .fields
-                .months
-                .ordinals()
-                .range(month_range)
-                .rev()
-                .cloned()
-            {
+            for month in fields.months.range(month_range).rev() {
                 let day_of_month_end = query.day_of_month_upper_bound();
-                if !self
-                    .fields
-                    .days_of_month
-                    .ordinals()
-                    .contains(&day_of_month_end)
-                {
+                if !fields.days_of_month.includes(day_of_month_end) {
                     query.reset_day_of_month();
                 }
 
@@ -269,21 +245,17 @@ impl Schedule {
                     Included(day_of_month_end),
                 );
 
-                let mut day_iter = self
-                    .fields
+                let mut day_iter = fields
                     .days_of_month
-                    .ordinals()
                     .range(day_of_month_range)
                     .rev()
-                    .cloned()
                     .filter(|&day| {
-                        self.fields.days_of_week.is_all()
+                        days_of_week_is_all
                             || NaiveDate::from_ymd_opt(year as i32, month, day)
                                 .map(|d| {
-                                    self.fields
+                                    fields
                                         .days_of_week
-                                        .ordinals()
-                                        .contains(&d.weekday().number_from_sunday())
+                                        .includes(d.weekday().number_from_sunday())
                                 })
                                 .unwrap_or(false)
                     })
@@ -293,19 +265,12 @@ impl Schedule {
                 }
                 for day_of_month in day_iter {
                     let hour_start = query.hour_upper_bound();
-                    if !self.fields.hours.ordinals().contains(&hour_start) {
+                    if !fields.hours.includes(hour_start) {
                         query.reset_hour();
                     }
                     let hour_range = (Included(Hours::inclusive_min()), Included(hour_start));
 
-                    for hour in self
-                        .fields
-                        .hours
-                        .ordinals()
-                        .range(hour_range)
-                        .rev()
-                        .cloned()
-                    {
+                    for hour in fields.hours.range(hour_range).rev() {
                         // See the forward `fold_hour_scan` for folded-time
                         // details. This is the reverse scan of the repeated
                         // hour from the second fold into the first.
@@ -320,41 +285,26 @@ impl Schedule {
                         } else {
                             query_minute_start
                         };
-                        if !self.fields.minutes.ordinals().contains(&minute_start) {
+                        if !fields.minutes.includes(minute_start) {
                             query.reset_minute();
                         }
                         let minute_range =
                             (Included(Minutes::inclusive_min()), Included(minute_start));
 
-                        for minute in self
-                            .fields
-                            .minutes
-                            .ordinals()
-                            .range(minute_range)
-                            .rev()
-                            .cloned()
-                        {
+                        for minute in fields.minutes.range(minute_range).rev() {
                             let query_second_start = query.second_upper_bound();
                             let second_start = if fold_hour_scan {
                                 Seconds::inclusive_max()
                             } else {
                                 query_second_start
                             };
-                            if !self.fields.seconds.ordinals().contains(&second_start) {
+                            if !fields.seconds.includes(second_start) {
                                 query.reset_second();
                             }
                             let second_range =
                                 (Included(Seconds::inclusive_min()), Included(second_start));
 
-                            for second in self
-                                .fields
-                                .seconds
-                                .ordinals()
-                                .range(second_range)
-                                .rev()
-                                .cloned()
-                            {
-                                let timezone = before.timezone();
+                            for second in fields.seconds.range(second_range).rev() {
                                 let local_result = timezone.with_ymd_and_hms(
                                     year as i32,
                                     month,

--- a/src/time_unit/days_of_month.rs
+++ b/src/time_unit/days_of_month.rs
@@ -1,17 +1,14 @@
 use crate::ordinal::{Ordinal, OrdinalSet};
 use crate::time_unit::TimeUnitField;
-use once_cell::sync::Lazy;
 use std::borrow::Cow;
-
-static ALL: Lazy<OrdinalSet> = Lazy::new(DaysOfMonth::supported_ordinals);
 
 #[derive(Clone, Debug, Eq)]
 pub struct DaysOfMonth {
-    ordinals: Option<OrdinalSet>,
+    ordinals: OrdinalSet,
 }
 
 impl TimeUnitField for DaysOfMonth {
-    fn from_optional_ordinal_set(ordinal_set: Option<OrdinalSet>) -> Self {
+    fn from_ordinal_set(ordinal_set: OrdinalSet) -> Self {
         DaysOfMonth {
             ordinals: ordinal_set,
         }
@@ -26,10 +23,7 @@ impl TimeUnitField for DaysOfMonth {
         31
     }
     fn ordinals(&self) -> &OrdinalSet {
-        match &self.ordinals {
-            Some(ordinal_set) => ordinal_set,
-            None => &ALL,
-        }
+        &self.ordinals
     }
 }
 

--- a/src/time_unit/days_of_week.rs
+++ b/src/time_unit/days_of_week.rs
@@ -1,7 +1,6 @@
 use crate::error::*;
 use crate::ordinal::{Ordinal, OrdinalSet};
 use crate::time_unit::TimeUnitField;
-use once_cell::sync::Lazy;
 use phf::phf_map;
 use std::borrow::Cow;
 
@@ -24,15 +23,13 @@ static DAY_OF_WEEK_MAP: phf::Map<&'static str, Ordinal> = phf_map! {
     "saturday" => 7,
 };
 
-static ALL: Lazy<OrdinalSet> = Lazy::new(DaysOfWeek::supported_ordinals);
-
 #[derive(Clone, Debug, Eq)]
 pub struct DaysOfWeek {
-    ordinals: Option<OrdinalSet>,
+    ordinals: OrdinalSet,
 }
 
 impl TimeUnitField for DaysOfWeek {
-    fn from_optional_ordinal_set(ordinal_set: Option<OrdinalSet>) -> Self {
+    fn from_ordinal_set(ordinal_set: OrdinalSet) -> Self {
         DaysOfWeek {
             ordinals: ordinal_set,
         }
@@ -55,10 +52,7 @@ impl TimeUnitField for DaysOfWeek {
             })
     }
     fn ordinals(&self) -> &OrdinalSet {
-        match &self.ordinals {
-            Some(ordinal_set) => ordinal_set,
-            None => &ALL,
-        }
+        &self.ordinals
     }
 }
 

--- a/src/time_unit/hours.rs
+++ b/src/time_unit/hours.rs
@@ -1,17 +1,14 @@
 use crate::ordinal::{Ordinal, OrdinalSet};
 use crate::time_unit::TimeUnitField;
-use once_cell::sync::Lazy;
 use std::borrow::Cow;
-
-static ALL: Lazy<OrdinalSet> = Lazy::new(Hours::supported_ordinals);
 
 #[derive(Clone, Debug, Eq)]
 pub struct Hours {
-    ordinals: Option<OrdinalSet>,
+    ordinals: OrdinalSet,
 }
 
 impl TimeUnitField for Hours {
-    fn from_optional_ordinal_set(ordinal_set: Option<OrdinalSet>) -> Self {
+    fn from_ordinal_set(ordinal_set: OrdinalSet) -> Self {
         Hours {
             ordinals: ordinal_set,
         }
@@ -26,10 +23,7 @@ impl TimeUnitField for Hours {
         23
     }
     fn ordinals(&self) -> &OrdinalSet {
-        match &self.ordinals {
-            Some(ordinal_set) => ordinal_set,
-            None => &ALL,
-        }
+        &self.ordinals
     }
 }
 

--- a/src/time_unit/minutes.rs
+++ b/src/time_unit/minutes.rs
@@ -1,17 +1,14 @@
 use crate::ordinal::{Ordinal, OrdinalSet};
 use crate::time_unit::TimeUnitField;
-use once_cell::sync::Lazy;
 use std::borrow::Cow;
-
-static ALL: Lazy<OrdinalSet> = Lazy::new(Minutes::supported_ordinals);
 
 #[derive(Clone, Debug, Eq)]
 pub struct Minutes {
-    ordinals: Option<OrdinalSet>,
+    ordinals: OrdinalSet,
 }
 
 impl TimeUnitField for Minutes {
-    fn from_optional_ordinal_set(ordinal_set: Option<OrdinalSet>) -> Self {
+    fn from_ordinal_set(ordinal_set: OrdinalSet) -> Self {
         Minutes {
             ordinals: ordinal_set,
         }
@@ -26,10 +23,7 @@ impl TimeUnitField for Minutes {
         59
     }
     fn ordinals(&self) -> &OrdinalSet {
-        match &self.ordinals {
-            Some(ordinal_set) => ordinal_set,
-            None => &ALL,
-        }
+        &self.ordinals
     }
 }
 

--- a/src/time_unit/mod.rs
+++ b/src/time_unit/mod.rs
@@ -15,44 +15,42 @@ pub use self::seconds::Seconds;
 pub use self::years::Years;
 
 use crate::error::*;
-use crate::ordinal::{Ordinal, OrdinalSet};
+use crate::ordinal::{Ordinal, OrdinalSet, OrdinalSetIter};
 use crate::specifier::{RootSpecifier, Specifier};
 use std::borrow::Cow;
-use std::collections::btree_set;
-use std::iter;
 use std::ops::RangeBounds;
 
 pub struct OrdinalIter<'a> {
-    set_iter: btree_set::Iter<'a, Ordinal>,
+    iter: OrdinalSetIter<'a>,
 }
 
 impl Iterator for OrdinalIter<'_> {
     type Item = Ordinal;
     fn next(&mut self) -> Option<Ordinal> {
-        self.set_iter.next().copied()
+        self.iter.next()
     }
 }
 
 impl DoubleEndedIterator for OrdinalIter<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.set_iter.next_back().copied()
+        self.iter.next_back()
     }
 }
 
 pub struct OrdinalRangeIter<'a> {
-    range_iter: btree_set::Range<'a, Ordinal>,
+    iter: OrdinalSetIter<'a>,
 }
 
 impl Iterator for OrdinalRangeIter<'_> {
     type Item = Ordinal;
     fn next(&mut self) -> Option<Ordinal> {
-        self.range_iter.next().copied()
+        self.iter.next()
     }
 }
 
 impl DoubleEndedIterator for OrdinalRangeIter<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.range_iter.next_back().copied()
+        self.iter.next_back()
     }
 }
 
@@ -177,11 +175,11 @@ where
     T: TimeUnitField,
 {
     fn includes(&self, ordinal: Ordinal) -> bool {
-        self.ordinals().contains(&ordinal)
+        self.ordinals().contains(ordinal)
     }
     fn iter(&self) -> OrdinalIter<'_> {
         OrdinalIter {
-            set_iter: TimeUnitField::ordinals(self).iter(),
+            iter: TimeUnitField::ordinals(self).iter(),
         }
     }
     fn range<R>(&'_ self, range: R) -> OrdinalRangeIter<'_>
@@ -189,16 +187,15 @@ where
         R: RangeBounds<Ordinal>,
     {
         OrdinalRangeIter {
-            range_iter: TimeUnitField::ordinals(self).range(range),
+            iter: TimeUnitField::ordinals(self).range(range),
         }
     }
     fn count(&self) -> u32 {
-        self.ordinals().len() as u32
+        self.ordinals().count()
     }
 
     fn is_all(&self) -> bool {
-        let max_supported_ordinals = Self::inclusive_max() - Self::inclusive_min() + 1;
-        self.ordinals().len() == max_supported_ordinals as usize
+        self.ordinals().is_all()
     }
 }
 
@@ -206,26 +203,30 @@ pub trait TimeUnitField
 where
     Self: Sized,
 {
-    fn from_optional_ordinal_set(ordinal_set: Option<OrdinalSet>) -> Self;
+    fn from_ordinal_set(ordinal_set: OrdinalSet) -> Self;
     fn name() -> Cow<'static, str>;
     fn inclusive_min() -> Ordinal;
     fn inclusive_max() -> Ordinal;
     fn ordinals(&self) -> &OrdinalSet;
 
     fn from_ordinal(ordinal: Ordinal) -> Self {
-        Self::from_ordinal_set(iter::once(ordinal).collect())
+        Self::from_ordinal_set(OrdinalSet::from_iter(
+            Self::inclusive_min(),
+            Self::inclusive_max(),
+            [ordinal],
+        ))
+    }
+
+    fn empty_ordinals() -> OrdinalSet {
+        OrdinalSet::empty(Self::inclusive_min(), Self::inclusive_max())
     }
 
     fn supported_ordinals() -> OrdinalSet {
-        (Self::inclusive_min()..Self::inclusive_max() + 1).collect()
+        OrdinalSet::all(Self::inclusive_min(), Self::inclusive_max())
     }
 
     fn all() -> Self {
-        Self::from_optional_ordinal_set(None)
-    }
-
-    fn from_ordinal_set(ordinal_set: OrdinalSet) -> Self {
-        Self::from_optional_ordinal_set(Some(ordinal_set))
+        Self::from_ordinal_set(Self::supported_ordinals())
     }
 
     fn ordinal_from_name(name: &str) -> Result<Ordinal, Error> {
@@ -264,10 +265,18 @@ where
         //println!("ordinals_from_specifier for {} => {:?}", Self::name(), specifier);
         match *specifier {
             All => Ok(Self::supported_ordinals()),
-            Point(ordinal) => Ok(([ordinal]).iter().cloned().collect()),
+            Point(ordinal) => Ok(OrdinalSet::from_iter(
+                Self::inclusive_min(),
+                Self::inclusive_max(),
+                [Self::validate_ordinal(ordinal)?],
+            )),
             Range(start, end) => {
                 match (Self::validate_ordinal(start), Self::validate_ordinal(end)) {
-                    (Ok(start), Ok(end)) if start <= end => Ok((start..end + 1).collect()),
+                    (Ok(start), Ok(end)) if start <= end => Ok(OrdinalSet::from_iter(
+                        Self::inclusive_min(),
+                        Self::inclusive_max(),
+                        start..=end,
+                    )),
                     _ => Err(ErrorKind::Expression(format!(
                         "Invalid range for {}: {}-{}",
                         Self::name(),
@@ -281,7 +290,11 @@ where
                 let start = Self::ordinal_from_name(start_name)?;
                 let end = Self::ordinal_from_name(end_name)?;
                 match (Self::validate_ordinal(start), Self::validate_ordinal(end)) {
-                    (Ok(start), Ok(end)) if start <= end => Ok((start..end + 1).collect()),
+                    (Ok(start), Ok(end)) if start <= end => Ok(OrdinalSet::from_iter(
+                        Self::inclusive_min(),
+                        Self::inclusive_max(),
+                        start..=end,
+                    )),
                     _ => Err(ErrorKind::Expression(format!(
                         "Invalid named range for {}: {}-{}",
                         Self::name(),
@@ -316,16 +329,25 @@ where
                     // point and terminating inclusively with the inclusive max
                     Specifier::Point(start) => {
                         let start = Self::validate_ordinal(*start)?;
-                        (start..=Self::inclusive_max()).collect()
+                        OrdinalSet::from_iter(
+                            Self::inclusive_min(),
+                            Self::inclusive_max(),
+                            start..=Self::inclusive_max(),
+                        )
                     }
                     specifier => Self::ordinals_from_specifier(specifier)?,
                 };
-                base_set.into_iter().step_by(*step as usize).collect()
+                OrdinalSet::from_iter(
+                    Self::inclusive_min(),
+                    Self::inclusive_max(),
+                    base_set.iter().step_by(*step as usize),
+                )
             }
-            RootSpecifier::NamedPoint(ref name) => ([Self::ordinal_from_name(name)?])
-                .iter()
-                .cloned()
-                .collect::<OrdinalSet>(),
+            RootSpecifier::NamedPoint(ref name) => OrdinalSet::from_iter(
+                Self::inclusive_min(),
+                Self::inclusive_max(),
+                [Self::validate_ordinal(Self::ordinal_from_name(name)?)?],
+            ),
         };
         Ok(ordinals)
     }

--- a/src/time_unit/months.rs
+++ b/src/time_unit/months.rs
@@ -1,7 +1,6 @@
 use crate::error::*;
 use crate::ordinal::{Ordinal, OrdinalSet};
 use crate::time_unit::TimeUnitField;
-use once_cell::sync::Lazy;
 use phf::phf_map;
 use std::borrow::Cow;
 
@@ -31,15 +30,13 @@ static MONTH_MAP: phf::Map<&'static str, Ordinal> = phf_map! {
     "december" => 12,
 };
 
-static ALL: Lazy<OrdinalSet> = Lazy::new(Months::supported_ordinals);
-
 #[derive(Clone, Debug, Eq)]
 pub struct Months {
-    ordinals: Option<OrdinalSet>,
+    ordinals: OrdinalSet,
 }
 
 impl TimeUnitField for Months {
-    fn from_optional_ordinal_set(ordinal_set: Option<OrdinalSet>) -> Self {
+    fn from_ordinal_set(ordinal_set: OrdinalSet) -> Self {
         Months {
             ordinals: ordinal_set,
         }
@@ -62,10 +59,7 @@ impl TimeUnitField for Months {
             })
     }
     fn ordinals(&self) -> &OrdinalSet {
-        match &self.ordinals {
-            Some(ordinal_set) => ordinal_set,
-            None => &ALL,
-        }
+        &self.ordinals
     }
 }
 

--- a/src/time_unit/seconds.rs
+++ b/src/time_unit/seconds.rs
@@ -1,17 +1,14 @@
 use crate::ordinal::{Ordinal, OrdinalSet};
 use crate::time_unit::TimeUnitField;
-use once_cell::sync::Lazy;
 use std::borrow::Cow;
-
-static ALL: Lazy<OrdinalSet> = Lazy::new(Seconds::supported_ordinals);
 
 #[derive(Clone, Debug, Eq)]
 pub struct Seconds {
-    ordinals: Option<OrdinalSet>,
+    ordinals: OrdinalSet,
 }
 
 impl TimeUnitField for Seconds {
-    fn from_optional_ordinal_set(ordinal_set: Option<OrdinalSet>) -> Self {
+    fn from_ordinal_set(ordinal_set: OrdinalSet) -> Self {
         Seconds {
             ordinals: ordinal_set,
         }
@@ -26,10 +23,7 @@ impl TimeUnitField for Seconds {
         59
     }
     fn ordinals(&self) -> &OrdinalSet {
-        match &self.ordinals {
-            Some(ordinal_set) => ordinal_set,
-            None => &ALL,
-        }
+        &self.ordinals
     }
 }
 

--- a/src/time_unit/years.rs
+++ b/src/time_unit/years.rs
@@ -1,17 +1,14 @@
 use crate::ordinal::{Ordinal, OrdinalSet};
 use crate::time_unit::TimeUnitField;
-use once_cell::sync::Lazy;
 use std::borrow::Cow;
-
-static ALL: Lazy<OrdinalSet> = Lazy::new(Years::supported_ordinals);
 
 #[derive(Clone, Debug, Eq)]
 pub struct Years {
-    ordinals: Option<OrdinalSet>,
+    ordinals: OrdinalSet,
 }
 
 impl TimeUnitField for Years {
-    fn from_optional_ordinal_set(ordinal_set: Option<OrdinalSet>) -> Self {
+    fn from_ordinal_set(ordinal_set: OrdinalSet) -> Self {
         Years {
             ordinals: ordinal_set,
         }
@@ -29,10 +26,7 @@ impl TimeUnitField for Years {
         2100
     }
     fn ordinals(&self) -> &OrdinalSet {
-        match &self.ordinals {
-            Some(ordinal_set) => ordinal_set,
-            None => &ALL,
-        }
+        &self.ordinals
     }
 }
 


### PR DESCRIPTION
## Summary
- Replace ordinal `BTreeSet` storage with compact `All`/bitset sets and fast range cursors.
- Route schedule iteration through `TimeUnitSpec::range/includes`.
- Add Criterion coverage for parse, includes, dense/sparse iteration, and DST/nonexistent-time cases.
- Compile benchmarks in CI with `cargo bench --no-run`.

## Tests
- `cargo build --verbose`
- `cargo test --verbose`
- `cargo test --verbose --all-features`
- `cargo bench --no-run`
- `cargo doc --no-deps --verbose`
- `cargo fmt -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`